### PR TITLE
Support text objects spread over multiple uncompressed objects

### DIFF
--- a/src/Document/Text/TextObject.php
+++ b/src/Document/Text/TextObject.php
@@ -12,4 +12,8 @@ class TextObject {
 
         return $this;
     }
+
+    public function isEmpty(): bool {
+        return $this->textOperators === [];
+    }
 }

--- a/src/Document/Text/TextObjectCollection.php
+++ b/src/Document/Text/TextObjectCollection.php
@@ -22,14 +22,19 @@ class TextObjectCollection {
         $this->textObjects = $textObjects;
     }
 
-    public function getText(Document $document, Page $page, ?Font &$font): string {
+    public function getText(Document $document, Page $page): string {
         $text = '';
+        $font = null;
         foreach ($this->textObjects as $textObject) {
             $textObjectText = '';
             foreach ($textObject->textOperators as $textOperator) {
                 if ($textOperator->operator instanceof TextPositioningOperator) {
                     $textObjectText .= $textOperator->operator->display($textOperator->operands);
                 } elseif ($textOperator->operator instanceof TextShowingOperator) {
+                    if ($font === null) {
+                        throw new ParseFailureException('A font should be selected before being used');
+                    }
+
                     $textObjectText .= $textOperator->operator->displayOperands($textOperator->operands, $font);
                 } elseif ($textOperator->operator === TextStateOperator::FONT_SIZE) {
                     if (($fontDictionary = $page->getFontDictionary()) === null) {


### PR DESCRIPTION
Fixes issue with missing text in #6 where a font operand is in uncompressed object A, and the operator is in object B, which would result in only the operator being found resulting in missing text.

Also fixes the font-by-reference workaround where fonts in uncompressed object A selected by the FontSize operator are still valid in object B. Now that we only have a single text object collection per page, this is always the case.