### PR TITLE
Use InMemoryStream for temporary substrings instead of writing to temporary file

### DIFF
--- a/src/Document/Object/Decorator/Font.php
+++ b/src/Document/Object/Decorator/Font.php
@@ -16,7 +16,7 @@ use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Reference\Reference
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\TextString\TextStringValue;
 use PrinsFrank\PdfParser\Document\Object\Item\UncompressedObject\UncompressedObject;
 use PrinsFrank\PdfParser\Exception\ParseFailureException;
-use PrinsFrank\PdfParser\Stream\FileStream;
+use PrinsFrank\PdfParser\Stream\InMemoryStream;
 
 class Font extends DecoratedObject {
     private readonly ToUnicodeCMap|false $toUnicodeCMap;
@@ -67,7 +67,7 @@ class Font extends DecoratedObject {
         }
 
         return $this->toUnicodeCMap = ToUnicodeCMapParser::parse(
-            $stream = FileStream::fromString($toUnicodeObject->objectItem->getStreamContent($this->document->stream)),
+            $stream = new InMemoryStream($toUnicodeObject->objectItem->getStreamContent($this->document->stream)),
             0,
             $stream->getSizeInBytes()
         );

--- a/src/Document/Object/Item/CompressedObject/CompressedObject.php
+++ b/src/Document/Object/Item/CompressedObject/CompressedObject.php
@@ -11,7 +11,7 @@ use PrinsFrank\PdfParser\Document\Object\Item\ObjectItem;
 use PrinsFrank\PdfParser\Document\Object\Item\UncompressedObject\UncompressedObject;
 use PrinsFrank\PdfParser\Exception\InvalidArgumentException;
 use PrinsFrank\PdfParser\Exception\RuntimeException;
-use PrinsFrank\PdfParser\Stream\FileStream;
+use PrinsFrank\PdfParser\Stream\InMemoryStream;
 use PrinsFrank\PdfParser\Stream\Stream;
 
 class CompressedObject implements ObjectItem {
@@ -37,7 +37,7 @@ class CompressedObject implements ObjectItem {
         $first = $this->storedInObject->getDictionary($stream)->getValueForKey(DictionaryKey::FIRST, IntegerValue::class)
             ?? throw new RuntimeException('Expected a dictionary entry for "First", none found');
 
-        $objectContent = FileStream::fromString(
+        $objectContent = new InMemoryStream(
             substr(
                 $this->storedInObject->getStreamContent($stream),
                 $first->value + $this->startByteOffsetInDecodedStream,


### PR DESCRIPTION
Relates to #7, this decreases run time by another 33%.