### PR TITLE
When in a string literal, don't keep track of other nesting levels as that is not possible, fixes several array delimiter issues in string literals

### DIFF
--- a/src/Document/ContentStream/ContentStreamParser.php
+++ b/src/Document/ContentStream/ContentStreamParser.php
@@ -27,21 +27,24 @@ class ContentStreamParser {
     public static function parse(string $contentStream): ContentStream {
         $operandBuffer = '';
         $content = [];
-        $inArrayLevel = $inStringLevel = $inStringLiteralLevel = 0;
+        $inStringLiteral = false;
+        $inArrayLevel = $inStringLevel = 0;
         $textObject = $previousChar = $secondToLastChar = $thirdToLastChar = null;
         foreach (($characters = str_split($contentStream)) as $index => $char) {
             $operandBuffer .= $char;
-            if ($char === '[' && $previousChar !== '\\') {
+            if ($inStringLiteral === true) {
+                if ($char === ')' && $previousChar !== '\\') {
+                    $inStringLiteral = false;
+                }
+            } elseif ($char === '[' && $previousChar !== '\\') {
                 $inArrayLevel++;
             } elseif ($char === '<' && $previousChar !== '\\') {
                 $inStringLevel++;
             } elseif ($char === '(' && $previousChar !== '\\') {
-                $inStringLiteralLevel++;
-            } elseif ($inStringLevel > 0 || $inStringLiteralLevel > 0 || $inArrayLevel > 0) {
+                $inStringLiteral = true;
+            } elseif ($inStringLevel > 0 || $inArrayLevel > 0) {
                 if ($inStringLevel > 0 && $char === '>' && $previousChar !== '\\') {
                     $inStringLevel--;
-                } elseif ($inStringLiteralLevel > 0 && $char === ')' && $previousChar !== '\\') {
-                    $inStringLiteralLevel--;
                 } elseif ($inArrayLevel > 0 && $char === ']' && $previousChar !== '\\') {
                     $inArrayLevel--;
                 }

--- a/tests/Unit/Document/Text/ContentStreamParserTest.php
+++ b/tests/Unit/Document/Text/ContentStreamParserTest.php
@@ -28,7 +28,7 @@ use PrinsFrank\PdfParser\Exception\RuntimeException;
 
 #[CoversClass(ContentStreamParser::class)]
 class ContentStreamParserTest extends TestCase {
-    public function testParseText(): void {
+    public function testParse(): void {
         static::assertEquals(
             new ContentStream(
                 (new TextObject())
@@ -48,7 +48,73 @@ class ContentStreamParserTest extends TestCase {
         );
     }
 
-    public function testParseTextWithOperatorInTextOperand(): void {
+    public function testParseWithArrayDelimiterInStringLiteral(): void {
+        static::assertEquals(
+            new ContentStream(
+                (new TextObject())
+                    ->addContentStreamCommand(new ContentStreamCommand(TextShowingOperator::SHOW, '([Hello)'))
+                    ->addContentStreamCommand(new ContentStreamCommand(TextShowingOperator::SHOW, '(World])'))
+            ),
+            ContentStreamParser::parse(
+                <<<EOD
+                BT
+                ([Hello) Tj
+                (World]) Tj
+                ET
+                EOD
+            )
+        );
+    }
+
+    public function testParseWithEscapedStringLiteralDelimiterInStringLiteral(): void {
+        static::assertEquals(
+            new ContentStream(
+                (new TextObject())
+                    ->addContentStreamCommand(new ContentStreamCommand(TextShowingOperator::SHOW, '(Hel\)lo)'))
+            ),
+            ContentStreamParser::parse(
+                <<<EOD
+                BT
+                (Hel\)lo) Tj
+                ET
+                EOD
+            )
+        );
+    }
+
+    public function testParseShowArraySyntax(): void {
+        static::assertEquals(
+            new ContentStream(
+                (new TextObject())
+                    ->addContentStreamCommand(new ContentStreamCommand(TextShowingOperator::SHOW_ARRAY, '[(F)-1(O)32(O)]'))
+            ),
+            ContentStreamParser::parse(
+                <<<EOD
+                BT
+                [(F)-1(O)32(O)] TJ
+                ET
+                EOD
+            )
+        );
+    }
+
+    public function testParseShowArraySyntaxWithArrayDelimiterInStringLiteral(): void {
+        static::assertEquals(
+            new ContentStream(
+                (new TextObject())
+                    ->addContentStreamCommand(new ContentStreamCommand(TextShowingOperator::SHOW_ARRAY, '[(F)-1([O)32(O])]'))
+            ),
+            ContentStreamParser::parse(
+                <<<EOD
+                BT
+                [(F)-1([O)32(O])] TJ
+                ET
+                EOD
+            )
+        );
+    }
+
+    public function testParseWithOperatorInTextOperand(): void {
         static::assertEquals(
             new ContentStream(
                 (new TextObject())


### PR DESCRIPTION
Fixes #108 