### PR TITLE
Add official support for pdf 2.0

### DIFF
--- a/src/Document/Version/Version.php
+++ b/src/Document/Version/Version.php
@@ -19,6 +19,7 @@ enum Version: string implements NameValue {
     case V1_5 = '1.5';
     case V1_6 = '1.6';
     case V1_7 = '1.7';
+    case V2_0 = '2.0';
 
     public static function length(): int {
         return 3;


### PR DESCRIPTION
A lot of work was done over the past few months with local samples to add support for PDF2.0. This finalizes that work by adding the 2.0 value to the Version enum. Fixes #122 