### PR TITLE
Add support for other colorspaces that are not DeviceColorSpaces but are stored as luts in objects

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Name/CIEColorSpaceNameValue.php
+++ b/src/Document/Dictionary/DictionaryValue/Name/CIEColorSpaceNameValue.php
@@ -2,9 +2,36 @@
 
 namespace PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name;
 
-enum CIEColorSpaceNameValue: string implements NameValue {
+use Override;
+use PrinsFrank\PdfParser\Document\Dictionary\DictionaryKey\DictionaryKey;
+use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Integer\IntegerValue;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\Components;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\HasComponents;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\LUT;
+use PrinsFrank\PdfParser\Exception\InvalidArgumentException;
+use PrinsFrank\PdfParser\Exception\ParseFailureException;
+use PrinsFrank\PdfParser\Exception\RuntimeException;
+
+enum CIEColorSpaceNameValue: string implements NameValue, HasComponents {
     case CalGray = 'CalGray';
     case CalRGB = 'CalRGB';
     case Lab = 'Lab';
     case ICCBased = 'ICCBased';
+
+    #[Override]
+    public function getComponents(?LUT $lut): Components {
+        if ($lut === null) {
+            throw new InvalidArgumentException('Unable to get components for CIEColorSpaceNameValue without LUT');
+        }
+
+        $type = $lut->decoratedObject->getDictionary()->getTypeForKey(DictionaryKey::N);
+        if ($type !== IntegerValue::class) {
+            throw new RuntimeException('Invalid ColorSpace object, missing N key');
+        }
+
+        $integerValue = $lut->decoratedObject->getDictionary()->getValueForKey(DictionaryKey::N, IntegerValue::class)
+            ?? throw new RuntimeException('Invalid ColorSpace object, missing N key');
+
+        return Components::tryFrom($integerValue->value) ?? throw new ParseFailureException(sprintf('Invalid number of components %d', $integerValue->value));
+    }
 }

--- a/src/Document/Dictionary/DictionaryValue/Name/DeviceColorSpaceNameValue.php
+++ b/src/Document/Dictionary/DictionaryValue/Name/DeviceColorSpaceNameValue.php
@@ -2,8 +2,22 @@
 
 namespace PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name;
 
-enum DeviceColorSpaceNameValue: string implements NameValue {
+use Override;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\Components;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\HasComponents;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\LUT;
+
+enum DeviceColorSpaceNameValue: string implements NameValue, HasComponents {
     case DeviceGray = 'DeviceGray';
     case DeviceRGB = 'DeviceRGB';
     case DeviceCMYK = 'DeviceCMYK';
+
+    #[Override]
+    public function getComponents(?LUT $lut): Components {
+        return match ($this) {
+            self::DeviceGray => Components::Gray,
+            self::DeviceRGB => Components::RGB,
+            self::DeviceCMYK => Components::CMYK,
+        };
+    }
 }

--- a/src/Document/Image/ColorSpace/ColorSpace.php
+++ b/src/Document/Image/ColorSpace/ColorSpace.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Document\Image\ColorSpace;
+
+use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\CIEColorSpaceNameValue;
+use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\DeviceColorSpaceNameValue;
+use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\SpecialColorSpaceNameValue;
+
+class ColorSpace {
+    public function __construct(
+        public readonly DeviceColorSpaceNameValue|CIEColorSpaceNameValue|SpecialColorSpaceNameValue $nameValue,
+        public readonly ?LUT $lutObject,
+    ) {
+    }
+
+    public function getComponents(): Components {
+        return $this->nameValue->getComponents($this->lutObject);
+    }
+}

--- a/src/Document/Image/ColorSpace/Components.php
+++ b/src/Document/Image/ColorSpace/Components.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Document\Image\ColorSpace;
+
+enum Components: int {
+    case Gray = 1;
+    case RGB = 3;
+    case CMYK = 4;
+}

--- a/src/Document/Image/ColorSpace/HasComponents.php
+++ b/src/Document/Image/ColorSpace/HasComponents.php
@@ -1,0 +1,7 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Document\Image\ColorSpace;
+
+interface HasComponents {
+    public function getComponents(?LUT $lut): Components;
+}

--- a/src/Document/Image/ColorSpace/LUT.php
+++ b/src/Document/Image/ColorSpace/LUT.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Document\Image\ColorSpace;
+
+use PrinsFrank\PdfParser\Document\Object\Decorator\DecoratedObject;
+
+class LUT {
+    public function __construct(
+        public readonly DecoratedObject $decoratedObject,
+    ) {
+    }
+}

--- a/src/Document/Image/RasterizedImage.php
+++ b/src/Document/Image/RasterizedImage.php
@@ -2,9 +2,8 @@
 
 namespace PrinsFrank\PdfParser\Document\Image;
 
-use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\CIEColorSpaceNameValue;
-use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\DeviceColorSpaceNameValue;
-use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\SpecialColorSpaceNameValue;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\ColorSpace;
+use PrinsFrank\PdfParser\Document\Image\ColorSpace\Components;
 use PrinsFrank\PdfParser\Exception\ParseFailureException;
 
 class RasterizedImage {
@@ -15,7 +14,7 @@ class RasterizedImage {
      * @param int<1, max> $height
      * @throws ParseFailureException
      */
-    public static function toPNG(CIEColorSpaceNameValue|DeviceColorSpaceNameValue|SpecialColorSpaceNameValue $colorSpace, int $width, int $height, int $bitsPerComponent, string $content): string {
+    public static function toPNG(ColorSpace $colorSpace, int $width, int $height, int $bitsPerComponent, string $content): string {
         if ($bitsPerComponent !== 8) {
             throw new ParseFailureException('Unsupported BitsPerComponent');
         }
@@ -28,10 +27,10 @@ class RasterizedImage {
         $pixelIndex = 0;
         for ($y = 0; $y < $height; $y++) {
             for ($x = 0; $x < $width; $x++) {
-                $color = match ($colorSpace) {
-                    DeviceColorSpaceNameValue::DeviceRGB => imagecolorallocate($image, ord($content[$pixelIndex++]), ord($content[$pixelIndex++]), ord($content[$pixelIndex++])),
-                    DeviceColorSpaceNameValue::DeviceGray => imagecolorallocate($image, $value = ord($content[$pixelIndex++]), $value, $value),
-                    default => throw new ParseFailureException('Unsupported colorspace: ' . $colorSpace->value),
+                $color = match ($colorSpace->getComponents()) {
+                    Components::RGB => imagecolorallocate($image, ord($content[$pixelIndex++]), ord($content[$pixelIndex++]), ord($content[$pixelIndex++])),
+                    Components::Gray => imagecolorallocate($image, $value = ord($content[$pixelIndex++]), $value, $value),
+                    default => throw new ParseFailureException('Unsupported components: ' . $colorSpace->getComponents()->name),
                 };
 
                 if ($color === false) {


### PR DESCRIPTION
Fixes #133, https://github.com/smalot/pdfparser/issues/774