### PR TITLE
Recover from invalid byte offset last cross reference section by looking for stream/table markers at the end of the document instead

### DIFF
--- a/src/Document/CrossReference/CrossReferenceSourceParser.php
+++ b/src/Document/CrossReference/CrossReferenceSourceParser.php
@@ -39,27 +39,54 @@ class CrossReferenceSourceParser {
         $eolPosByteOffset = $stream->getEndOfCurrentLine($byteOffsetLastCrossReferenceSection, $stream->getSizeInBytes())
             ?? throw new ParseFailureException('Expected a newline after byte offset for last cross reference stream');
 
-        $isTable = trim($stream->read($byteOffsetLastCrossReferenceSection, $eolPosByteOffset - $byteOffsetLastCrossReferenceSection)) === Marker::XREF->value;
-        $endCrossReferenceSection = $isTable
+        $crossReferenceType = self::getCrossReferenceType($stream, $byteOffsetLastCrossReferenceSection, $eolPosByteOffset);
+        if ($crossReferenceType === null) { // Try to recover from an invalid byte offset crossReference section
+            $lastPosXrefSection = $stream->lastPos(Marker::XREF, $stream->getSizeInBytes() - $startXrefMarkerPos);
+            $lastPosObject = $stream->lastPos(Marker::OBJ, $stream->getSizeInBytes() - $startXrefMarkerPos);
+            if ($lastPosXrefSection === null && $lastPosObject === null) {
+                throw new ParseFailureException(sprintf('Unable to determine cross reference type for start line "%s" of crossReference source, and no other crossReference table or stream was found.', $stream->read($byteOffsetLastCrossReferenceSection, $eolPosByteOffset - $byteOffsetLastCrossReferenceSection)));
+            }
+
+            $lastPossibleXrefSectionPos = $lastPosObject === null ? $lastPosXrefSection : ($lastPosXrefSection === null ? $lastPosObject : max($lastPosXrefSection, $lastPosObject));
+            $eolStartXrefSectionPos = $stream->getEndOfCurrentLine($lastPossibleXrefSectionPos, $stream->getSizeInBytes())
+                ?? throw new ParseFailureException(sprintf('Unable to determine cross reference type for start line "%s" of crossReference source, and no other crossReference table or stream was found.', $stream->read($startByteOffset, $endByteOffset - $startByteOffset)));
+            $crossReferenceType = self::getCrossReferenceType($stream, $lastPossibleXrefSectionPos, $eolStartXrefSectionPos)
+                ?? throw new ParseFailureException(sprintf('Unable to determine cross reference type for start line "%s" of crossReference source, and no other crossReference table or stream was found.', $stream->read($startByteOffset, $endByteOffset - $startByteOffset)));
+        }
+
+        $endCrossReferenceSection = $crossReferenceType === CrossReferenceType::Table
             ? ($stream->firstPos(Marker::START_XREF, $eolPosByteOffset, $stream->getSizeInBytes()) ?? throw new ParseFailureException(sprintf('Unable to locate marker %s', Marker::START_XREF->value)))
             : ($stream->firstPos(Marker::END_OBJ, $eolPosByteOffset, $stream->getSizeInBytes()) ?? throw new ParseFailureException(sprintf('Unable to locate marker %s', Marker::END_OBJ->value)));
-        $currentCrossReferenceSection = $isTable
+        $currentCrossReferenceSection = $crossReferenceType === CrossReferenceType::Table
             ? CrossReferenceTableParser::parse($stream, $eolPosByteOffset, $endCrossReferenceSection - $eolPosByteOffset)
             : CrossReferenceStreamParser::parse($stream, $eolPosByteOffset, $endCrossReferenceSection - $eolPosByteOffset);
         $crossReferenceSections = [$currentCrossReferenceSection];
         while (($previous = $currentCrossReferenceSection->dictionary->getValueForKey(DictionaryKey::PREV, IntegerValue::class)) !== null && $previous->value !== 0) {
             $eolPosByteOffset = $stream->getEndOfCurrentLine($previous->value + 1, $stream->getSizeInBytes())
                 ?? throw new ParseFailureException('Expected a newline after byte offset for cross reference stream');
-            $endCrossReferenceSection = $isTable
+            $endCrossReferenceSection = $crossReferenceType === CrossReferenceType::Table
                 ? $stream->firstPos(Marker::START_XREF, $eolPosByteOffset, $stream->getSizeInBytes()) ?? throw new ParseFailureException('Unable to locate startxref')
                 : $stream->firstPos(Marker::END_OBJ, $eolPosByteOffset, $stream->getSizeInBytes()) ?? throw new ParseFailureException('Unable to locate endobj');
 
-            $currentCrossReferenceSection = $isTable
+            $currentCrossReferenceSection = $crossReferenceType === CrossReferenceType::Table
                 ? CrossReferenceTableParser::parse($stream, $eolPosByteOffset, $endCrossReferenceSection - $eolPosByteOffset)
                 : CrossReferenceStreamParser::parse($stream, $eolPosByteOffset, $endCrossReferenceSection - $eolPosByteOffset);
             $crossReferenceSections[] = $currentCrossReferenceSection;
         }
 
         return new CrossReferenceSource(... $crossReferenceSections);
+    }
+
+    private static function getCrossReferenceType(Stream $stream, int $byteOffsetLastCrossReferenceSection, int $byteOffsetEndOfCurrentLine): ?CrossReferenceType {
+        $startCrossReferenceContent = trim($stream->read($byteOffsetLastCrossReferenceSection, $byteOffsetEndOfCurrentLine - $byteOffsetLastCrossReferenceSection));
+        if ($startCrossReferenceContent === Marker::XREF->value) {
+            return CrossReferenceType::Table;
+        }
+
+        if (preg_match('/^[0-9]*\s*[0-9]*\s*obj$/', $startCrossReferenceContent) === 1) {
+            return CrossReferenceType::Stream;
+        }
+
+        return null;
     }
 }

--- a/src/Document/CrossReference/CrossReferenceType.php
+++ b/src/Document/CrossReference/CrossReferenceType.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Document\CrossReference;
+
+enum CrossReferenceType {
+    case Table;
+    case Stream;
+}


### PR DESCRIPTION
Fixes #185 