### PR TITLE
Don't parse characters in resource names as operators

### DIFF
--- a/src/Document/ContentStream/ContentStreamParser.php
+++ b/src/Document/ContentStream/ContentStreamParser.php
@@ -27,7 +27,7 @@ class ContentStreamParser {
     public static function parse(string $contentStream): ContentStream {
         $operandBuffer = '';
         $content = [];
-        $inStringLiteral = false;
+        $inStringLiteral = $inResourceName = false;
         $inArrayLevel = $inStringLevel = 0;
         $textObject = $previousChar = $secondToLastChar = $thirdToLastChar = null;
         foreach (($characters = str_split($contentStream)) as $index => $char) {
@@ -36,12 +36,18 @@ class ContentStreamParser {
                 if ($char === ')' && $previousChar !== '\\') {
                     $inStringLiteral = false;
                 }
+            } elseif ($inResourceName === true) {
+                if (in_array($char, [' ', '<', '(', '/'], true) && $previousChar !== '\\') {
+                    $inResourceName = false;
+                }
             } elseif ($char === '[' && $previousChar !== '\\') {
                 $inArrayLevel++;
             } elseif ($char === '<' && $previousChar !== '\\') {
                 $inStringLevel++;
             } elseif ($char === '(' && $previousChar !== '\\') {
                 $inStringLiteral = true;
+            } elseif ($char === '/' && $previousChar !== '\\') {
+                $inResourceName = true;
             } elseif ($inStringLevel > 0 || $inArrayLevel > 0) {
                 if ($inStringLevel > 0 && $char === '>' && $previousChar !== '\\') {
                     $inStringLevel--;

--- a/tests/Unit/Document/Text/ContentStreamParserTest.php
+++ b/tests/Unit/Document/Text/ContentStreamParserTest.php
@@ -199,6 +199,22 @@ class ContentStreamParserTest extends TestCase {
         );
     }
 
+    public function testParseWithOperatorInResourceName(): void {
+        static::assertEquals(
+            new ContentStream(
+                (new TextObject())
+                    ->addContentStreamCommand(new ContentStreamCommand(TextStateOperator::FONT_SIZE, '/Helvetica-2000805986 24'))
+            ),
+            ContentStreamParser::parse(
+                <<<EOD
+                BT
+                /Helvetica-2000805986 24 Tf
+                ET
+                EOD
+            )
+        );
+    }
+
     #[DataProvider('provideOperators')]
     public function testGetOperator(CompatibilityOperator|InlineImageOperator|MarkedContentOperator|TextObjectOperator|ClippingPathOperator|ColorOperator|GraphicsStateOperator|PathConstructionOperator|PathPaintingOperator|TextPositioningOperator|TextShowingOperator|TextStateOperator|Type3FontOperator|XObjectOperator $enumCase): void {
         static::assertSame(


### PR DESCRIPTION
Fixes #194 