### PR TITLE
Array values can be multiple resource names not seperated by space

### DIFF
--- a/src/Document/Dictionary/DictionaryKey/DictionaryKey.php
+++ b/src/Document/Dictionary/DictionaryKey/DictionaryKey.php
@@ -1007,7 +1007,7 @@ enum DictionaryKey: string implements DictionaryKeyInterface {
             self::NR => [BooleanValue::class],
             self::NU => [DictionaryArrayValue::class],
             self::NUM_COPIES => [IntegerValue::class],
-            self::NUMS => [ArrayValue::class],
+            self::NUMS => [TextStringValue::class],
             self::O => [TextStringValue::class, IntegerValue::class, FloatValue::class, Dictionary::class, ArrayValue::class, BooleanValue::class],
             self::OB => [TextStringValue::class],
             self::OC => [Dictionary::class],

--- a/src/Document/Dictionary/DictionaryKey/DictionaryKey.php
+++ b/src/Document/Dictionary/DictionaryKey/DictionaryKey.php
@@ -1015,7 +1015,7 @@ enum DictionaryKey: string implements DictionaryKeyInterface {
             self::OCPROPERTIES => [Dictionary::class],
             self::OFF => [ArrayValue::class],
             self::OID => [ArrayValue::class],
-            self::ON => [ArrayValue::class],
+            self::ON => [ReferenceValueArray::class, ArrayValue::class],
             self::ON_INSTANTIATE => [TextStringValue::class],
             self::OP => [BooleanValue::class, IntegerValue::class],
             self::OP_L => [TextStringValue::class],

--- a/src/Document/Dictionary/DictionaryValue/Array/ArrayValue.php
+++ b/src/Document/Dictionary/DictionaryValue/Array/ArrayValue.php
@@ -26,7 +26,10 @@ class ArrayValue implements DictionaryValue {
 
         $valueString = preg_replace('/(<[^>]*>)(?=<[^>]*>)/', '$1 $2', $valueString)
             ?? throw new RuntimeException('An error occurred while sanitizing array value');
-        $values = explode(' ', str_replace("\n", ' ', rtrim(ltrim($valueString, '[ '), ' ]')));
+        $valueString = str_replace(['/', "\n"], [' /', ' '], rtrim(ltrim($valueString, '[ '), ' ]'));
+        $valueString = preg_replace('/\s+/', ' ', $valueString)
+            ?? throw new RuntimeException('An error occurred while removing duplicate spaces from array value');
+        $values = explode(' ', $valueString);
         if (count($values) % 3 === 0 && array_key_exists(2, $values) && $values[2] === 'R') {
             return ReferenceValueArray::fromValue($valueString);
         }

--- a/tests/Unit/Document/Dictionary/DictionaryParserTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryParserTest.php
@@ -247,7 +247,7 @@ class DictionaryParserTest extends TestCase {
         );
         static::assertEquals(
             new Dictionary(
-                new DictionaryEntry(DictionaryKey::OPEN_ACTION, new ArrayValue([3, 0, 'R/Fit'])),
+                new DictionaryEntry(DictionaryKey::OPEN_ACTION, new ArrayValue([3, 0, 'R', '/Fit'])),
                 new DictionaryEntry(DictionaryKey::PAGE_MODE, PageModeNameValue::USE_OUTLINES),
                 new DictionaryEntry(DictionaryKey::PAGE_LABELS, new Dictionary(
                     new DictionaryEntry(DictionaryKey::NUMS, new TextStringValue('[0<</S/r>>12<</S/D>>]')),

--- a/tests/Unit/Document/Dictionary/DictionaryParserTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryParserTest.php
@@ -250,7 +250,7 @@ class DictionaryParserTest extends TestCase {
                 new DictionaryEntry(DictionaryKey::OPEN_ACTION, new ArrayValue([3, 0, 'R/Fit'])),
                 new DictionaryEntry(DictionaryKey::PAGE_MODE, PageModeNameValue::USE_OUTLINES),
                 new DictionaryEntry(DictionaryKey::PAGE_LABELS, new Dictionary(
-                    new DictionaryEntry(DictionaryKey::NUMS, new ArrayValue(['0<</S/r>>12<</S/D>>'])),
+                    new DictionaryEntry(DictionaryKey::NUMS, new TextStringValue('[0<</S/r>>12<</S/D>>]')),
                 )),
                 new DictionaryEntry(DictionaryKey::NAMES, new ReferenceValue(13164, 0)),
                 new DictionaryEntry(DictionaryKey::OUTLINES, new ReferenceValue(13165, 0)),

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Array/ArrayValueTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Array/ArrayValueTest.php
@@ -28,6 +28,14 @@ class ArrayValueTest extends TestCase {
             ArrayValue::fromValue('[foo bar]'),
         );
         static::assertEquals(
+            new ArrayValue(['/foo', '/bar']),
+            ArrayValue::fromValue('[/foo/bar]'),
+        );
+        static::assertEquals(
+            new ArrayValue([3, 0, 'R', '/FitH', 'null']),
+            ArrayValue::fromValue('[3 0 R /FitH null]'),
+        );
+        static::assertEquals(
             new ArrayValue([42, 43, 44]),
             ArrayValue::fromValue(
                 <<<EOD


### PR DESCRIPTION
Fixes #180 