### PR TITLE
ci.yml: added PHP 8.5 as a test target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     uses: prinsfrank/CI-PHP/.github/workflows/quality.yml@main
     with:
       PHP_VERSION: '8.3'
-      PHP_VERSIONS: '["8.2", "8.3", "8.4"]'
+      PHP_VERSIONS: '["8.2", "8.3", "8.4", "8.5"]'
     secrets: inherit
 
   feature:
@@ -25,7 +25,7 @@ jobs:
       PHP_VERSION: '8.3'
     strategy:
       matrix:
-        php-version: ["8.2", "8.3", "8.4"]
+        php-version: ["8.2", "8.3", "8.4", "8.5"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
PHP 8.5 beta 1 was released recently, so its a good time to include it: https://www.php.net/archive/2025.php#2025-08-14-1