### PR TITLE
Empty arrays are currently properly supported, but empty reference value arrays result in errors

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArray.php
+++ b/src/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArray.php
@@ -26,7 +26,12 @@ class ReferenceValueArray implements DictionaryValue {
 
         $valueString = preg_replace('/\s+/', ' ', $valueString)
             ?? throw new ParseFailureException('An unexpected error occurred while sanitizing reference value array');
-        $referenceParts = explode(' ', trim(rtrim(ltrim($valueString, '['), ']')));
+        $valueString = trim(rtrim(ltrim($valueString, '['), ']'));
+        if ($valueString === '') {
+            return new self();
+        }
+
+        $referenceParts = explode(' ', $valueString);
         $nrOfReferenceParts = count($referenceParts);
         if ($nrOfReferenceParts % 3 !== 0) {
             return null;

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArrayTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArrayTest.php
@@ -13,7 +13,10 @@ class ReferenceValueArrayTest extends TestCase {
         static::assertNull(ReferenceValueArray::fromValue('42'));
         static::assertNull(ReferenceValueArray::fromValue('42 0'));
         static::assertNull(ReferenceValueArray::fromValue('42 0 R'));
-        static::assertNull(ReferenceValueArray::fromValue('[]'));
+        static::assertEquals(
+            new ReferenceValueArray(),
+            ReferenceValueArray::fromValue('[]')
+        );
         static::assertEquals(
             new ReferenceValueArray(
                 new ReferenceValue(42, 0)


### PR DESCRIPTION
fixes #230