### PR TITLE
Normalize name values to add support for hex encoded characters in name objects (7.3.5)

### DIFF
--- a/src/Document/Dictionary/DictionaryEntry/DictionaryEntryFactory.php
+++ b/src/Document/Dictionary/DictionaryEntry/DictionaryEntryFactory.php
@@ -13,6 +13,7 @@ use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\DictionaryValue;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\NameValue;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Reference\ReferenceValue;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\TextString\TextStringValue;
+use PrinsFrank\PdfParser\Document\Dictionary\Normalization\NameValueNormalizer;
 use PrinsFrank\PdfParser\Exception\ParseFailureException;
 use PrinsFrank\PdfParser\Exception\PdfParserException;
 
@@ -50,7 +51,7 @@ class DictionaryEntryFactory {
         foreach ($allowedValueTypes as $allowedValueType) {
             if (is_a($allowedValueType, BackedEnum::class, true)
                 && is_string($value)
-                && ($resolvedValue = $allowedValueType::tryFrom(trim(ltrim($value, '/')))) !== null) {
+                && ($resolvedValue = $allowedValueType::tryFrom(NameValueNormalizer::normalize($value))) !== null) {
                 return $resolvedValue;
             }
         }

--- a/src/Document/Dictionary/Normalization/NameValueNormalizer.php
+++ b/src/Document/Dictionary/Normalization/NameValueNormalizer.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Document\Dictionary\Normalization;
+
+use PrinsFrank\PdfParser\Exception\RuntimeException;
+
+class NameValueNormalizer {
+    /** @throws RuntimeException */
+    public static function normalize(string $name): string {
+        $value = ltrim($name, '/');
+        $value = preg_replace_callback(
+            '/#([0-9A-Fa-f]{2})/',
+            static function (array $matches): string {
+                if (!is_int($codePoint = hexdec($matches[1]))) {
+                    throw new RuntimeException('An unexpected error occurred while normalizing name value');
+                }
+
+                return mb_chr($codePoint, 'UTF-8');
+            },
+            $value,
+        ) ?? throw new RuntimeException('An unexpected error occurred while normalizing name value');
+
+        return trim($value);
+    }
+}

--- a/tests/Unit/Document/Dictionary/DictionaryEntry/DictionaryEntryFactoryTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryEntry/DictionaryEntryFactoryTest.php
@@ -9,6 +9,7 @@ use PrinsFrank\PdfParser\Document\Dictionary\DictionaryEntry\DictionaryEntryFact
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryKey\DictionaryKey;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\TabsNameValue;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\TextString\TextStringValue;
+use PrinsFrank\PdfParser\Document\Version\Version;
 
 #[CoversClass(DictionaryEntryFactory::class)]
 class DictionaryEntryFactoryTest extends TestCase {
@@ -21,6 +22,11 @@ class DictionaryEntryFactoryTest extends TestCase {
             new DictionaryEntry(DictionaryKey::TABS, new TextStringValue('(S)')),
             DictionaryEntryFactory::fromKeyValuePair('/Tabs', '(S)'),
             'Bug in LibreOffice: https://bugs.documentfoundation.org/show_bug.cgi?id=155228'
+        );
+        static::assertEquals(
+            new DictionaryEntry(DictionaryKey::VERSION, Version::V1_5),
+            DictionaryEntryFactory::fromKeyValuePair('/Version', '/1#2E5'),
+            'Support for hex values in name objects, see #7.3.5'
         );
     }
 }

--- a/tests/Unit/Document/Dictionary/Normalization/NameValueNormalizerTest.php
+++ b/tests/Unit/Document/Dictionary/Normalization/NameValueNormalizerTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace PrinsFrank\PdfParser\Tests\Unit\Document\Dictionary\Normalization;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use PrinsFrank\PdfParser\Document\Dictionary\Normalization\NameValueNormalizer;
+
+#[CoversClass(NameValueNormalizer::class)]
+class NameValueNormalizerTest extends TestCase {
+    public function testNormalize(): void {
+        static::assertSame('', NameValueNormalizer::normalize(''));
+        static::assertSame('Foo', NameValueNormalizer::normalize('Foo'));
+        static::assertSame('Foo', NameValueNormalizer::normalize('/Foo'));
+        static::assertSame('F.o', NameValueNormalizer::normalize('/F.o'));
+        static::assertSame('F.o', NameValueNormalizer::normalize('/F#2Eo'));
+        static::assertSame('Foo Bar', NameValueNormalizer::normalize('/Foo#20Bar'));
+    }
+}


### PR DESCRIPTION
fixes #229 