### PR TITLE
Fix bug where dictionary arrays are parsed as reference arrays when its number of components is divisible by 3

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArray.php
+++ b/src/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArray.php
@@ -27,6 +27,10 @@ class ReferenceValueArray implements DictionaryValue {
         $valueString = preg_replace('/\s+/', ' ', $valueString)
             ?? throw new ParseFailureException('An unexpected error occurred while sanitizing reference value array');
         $valueString = trim(rtrim(ltrim($valueString, '['), ']'));
+        if (str_starts_with($valueString, '<<') && str_ends_with($valueString, '>>')) {
+            return null;
+        }
+
         if ($valueString === '') {
             return new self();
         }

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArrayTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Reference/ReferenceValueArrayTest.php
@@ -13,6 +13,10 @@ class ReferenceValueArrayTest extends TestCase {
         static::assertNull(ReferenceValueArray::fromValue('42'));
         static::assertNull(ReferenceValueArray::fromValue('42 0'));
         static::assertNull(ReferenceValueArray::fromValue('42 0 R'));
+        static::assertNull(
+            ReferenceValueArray::fromValue('[<< /Foo 42 /Bar 43 >>]'),
+            'Has 6 parts, but starts with << and ends with >> so should not be parsed as reference value array'
+        );
         static::assertEquals(
             new ReferenceValueArray(),
             ReferenceValueArray::fromValue('[]')


### PR DESCRIPTION
See https://github.com/PrinsFrank/pdfparser/issues/256#issuecomment-3399996650