### PR TITLE
Exit from resource name on newline when parsing content streams

### DIFF
--- a/src/Document/ContentStream/ContentStreamParser.php
+++ b/src/Document/ContentStream/ContentStreamParser.php
@@ -44,7 +44,7 @@ class ContentStreamParser {
                         $inStringLiteral = false;
                     }
                 } elseif ($inResourceName === true) {
-                    if (in_array($char, [' ', '<', '(', '/'], true) && $previousChar !== '\\') {
+                    if (in_array($char, [' ', '<', '(', '/', "\r", "\n"], true) && $previousChar !== '\\') {
                         $inResourceName = false;
                     }
                 } elseif ($char === '[' && $previousChar !== '\\') {

--- a/tests/Unit/Document/Text/ContentStreamParserTest.php
+++ b/tests/Unit/Document/Text/ContentStreamParserTest.php
@@ -257,6 +257,24 @@ class ContentStreamParserTest extends TestCase {
         );
     }
 
+    public function testParseWithResourceNameFollowedByLineEnding(): void {
+        $contentStream = FileStream::fromString(
+            <<<EOD
+            BT
+            /Artifact
+            ET
+            EOD
+        );
+        $decoratedObject = $this->createMock(GenericObject::class);
+        $decoratedObject->expects(self::once())->method('getStream')->willReturn($contentStream);
+        static::assertEquals(
+            new ContentStream(
+                (new TextObject())
+            ),
+            ContentStreamParser::parse([$decoratedObject])
+        );
+    }
+
     #[DataProvider('provideOperators')]
     public function testGetOperator(CompatibilityOperator|InlineImageOperator|MarkedContentOperator|TextObjectOperator|ClippingPathOperator|ColorOperator|GraphicsStateOperator|PathConstructionOperator|PathPaintingOperator|TextPositioningOperator|TextShowingOperator|TextStateOperator|Type3FontOperator|XObjectOperator $enumCase): void {
         static::assertSame(


### PR DESCRIPTION
fixes #283 