### PR TITLE
feat(rectangle): add width and height helpers

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Rectangle/Rectangle.php
+++ b/src/Document/Dictionary/DictionaryValue/Rectangle/Rectangle.php
@@ -16,6 +16,14 @@ class Rectangle implements DictionaryValue {
         public readonly float $yBottomRight,
     ) {}
 
+    public function getWidth(): float {
+        return abs($this->xBottomRight - $this->xTopLeft);
+    }
+
+    public function getHeight(): float {
+        return abs($this->yBottomRight - $this->yTopLeft);
+    }
+
     #[Override]
     public static function fromValue(string $valueString): ?self {
         if (!str_starts_with($valueString, '[') || !str_ends_with($valueString, ']')) {

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Rectangle/RectangleTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Rectangle/RectangleTest.php
@@ -3,11 +3,25 @@
 namespace PrinsFrank\PdfParser\Tests\Unit\Document\Dictionary\DictionaryValue\Rectangle;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Rectangle\Rectangle;
 
 #[CoversClass(Rectangle::class)]
 class RectangleTest extends TestCase {
+    /** @return iterable<string, array{0: Rectangle, 1: float, 2: float}> */
+    public static function provideRectanglesWithExpectedDimensions(): iterable {
+        yield 'normal coordinates' => [new Rectangle(42.22, 43.33, 44.44, 45.55), 2.22, 2.22];
+        yield 'inverted coordinates' => [new Rectangle(44.44, 45.55, 42.22, 43.33), 2.22, 2.22];
+        yield 'zero width and height' => [new Rectangle(10.0, 20.0, 10.0, 20.0), 0.0, 0.0];
+    }
+
+    #[DataProvider('provideRectanglesWithExpectedDimensions')]
+    public function testGetWidthAndHeight(Rectangle $rectangle, float $expectedWidth, float $expectedHeight): void {
+        static::assertEqualsWithDelta($expectedWidth, $rectangle->getWidth(), 0.00001);
+        static::assertEqualsWithDelta($expectedHeight, $rectangle->getHeight(), 0.00001);
+    }
+
     public function testFromValue(): void {
         static::assertNull(Rectangle::fromValue(''));
         static::assertNull(Rectangle::fromValue('[]'));


### PR DESCRIPTION
## Summary

Adds helper methods to compute rectangle width and height directly from rectangle coordinates.

## Usage

```php
$document = (new PdfParser())->parseFile('sampleFile.pdf');

foreach ($document->getPages() as $page) {
    $rectangle = $page->getCropBox() ?? $page->getMediaBox();
    $width = $rectangle?->getWidth();
    $height = $rectangle?->getHeight();
}
```