### PR TITLE
Value for dictionaryKey AP can be a single dictionary

### DIFF
--- a/src/Document/Dictionary/DictionaryKey/DictionaryKey.php
+++ b/src/Document/Dictionary/DictionaryKey/DictionaryKey.php
@@ -687,7 +687,7 @@ enum DictionaryKey: string implements DictionaryKeyInterface {
             self::ANNOTATIONS => [IntegerValue::class],
             self::ANNOTS => [ReferenceValue::class, ReferenceValueArray::class, DictionaryArrayValue::class],
             self::ANTI_ALIAS => [BooleanValue::class],
-            self::AP => [DictionaryArrayValue::class],
+            self::AP => [DictionaryArrayValue::class, Dictionary::class],
             self::APREF => [Dictionary::class],
             self::ART_BOX => [Rectangle::class],
             self::AS => [DictionaryArrayValue::class, TextStringValue::class],


### PR DESCRIPTION
fixes #318