### PR TITLE
Fix boolean parsing compatibility for slash-prefixed literals

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Boolean/BooleanValue.php
+++ b/src/Document/Dictionary/DictionaryValue/Boolean/BooleanValue.php
@@ -11,13 +11,18 @@ class BooleanValue implements DictionaryValue {
         public readonly bool $value,
     ) {}
 
+    /**
+     * ISO 32000-2:2020, 7.3.2 defines booleans as the keywords true/false.
+     * ISO 32000-2:2020, 7.3.5 defines /true and /false as name objects.
+     * This parser also accepts slash-prefixed forms as a non-standard recovery path for malformed PDFs.
+     */
     #[Override]
     public static function fromValue(string $valueString): ?self {
-        if ($valueString === 'true') {
+        if ($valueString === 'true' || $valueString === '/true') {
             return new self(true);
         }
 
-        if ($valueString === 'false') {
+        if ($valueString === 'false' || $valueString === '/false') {
             return new self(false);
         }
 

--- a/tests/Unit/Document/Dictionary/DictionaryEntry/DictionaryEntryFactoryTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryEntry/DictionaryEntryFactoryTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryEntry\DictionaryEntry;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryEntry\DictionaryEntryFactory;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryKey\DictionaryKey;
+use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Boolean\BooleanValue;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Name\TabsNameValue;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\TextString\TextStringValue;
 use PrinsFrank\PdfParser\Document\Version\Version;
@@ -27,6 +28,10 @@ class DictionaryEntryFactoryTest extends TestCase {
             new DictionaryEntry(DictionaryKey::VERSION, Version::V1_5),
             DictionaryEntryFactory::fromKeyValuePair('/Version', '/1#2E5'),
             'Support for hex values in name objects, see #7.3.5',
+        );
+        static::assertEquals(
+            new DictionaryEntry(DictionaryKey::MARKED, new BooleanValue(true)),
+            DictionaryEntryFactory::fromKeyValuePair('/Marked', '/true'),
         );
     }
 }

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Boolean/BooleanValueTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Boolean/BooleanValueTest.php
@@ -18,8 +18,16 @@ class BooleanValueTest extends TestCase {
             BooleanValue::fromValue('true'),
         );
         static::assertEquals(
+            new BooleanValue(true),
+            BooleanValue::fromValue('/true'),
+        );
+        static::assertEquals(
             new BooleanValue(false),
             BooleanValue::fromValue('false'),
+        );
+        static::assertEquals(
+            new BooleanValue(false),
+            BooleanValue::fromValue('/false'),
         );
     }
 }


### PR DESCRIPTION
## Summary
- accept `/true` and `/false` in `BooleanValue::fromValue()` as compatibility fallback
- document ISO distinction in method docblock (`7.3.2` booleans vs `7.3.5` names)
- add regression coverage for slash-prefixed booleans and `/Marked /true` dictionary parsing

## Why
ISO 32000-2 defines booleans as `true`/`false`, while `/true` and `/false` are name objects. Some malformed PDFs use slash-prefixed forms in boolean fields; this change makes parsing while documenting that behavior as fallback compatibility.
