### PR TITLE
Pin test suite timezone to UTC so date tests are host-independent

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,5 +29,6 @@
     </source>
     <php>
         <ini name="memory_limit" value="256M"/>
+        <ini name="date.timezone" value="UTC"/>
     </php>
 </phpunit>

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Date/DateValueTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Date/DateValueTest.php
@@ -23,7 +23,7 @@ class DateValueTest extends TestCase {
             DateValue::fromValue('<ff>'),
         );
 
-        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2000-01-01 12:00:00');
+        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2000-01-01 12:00:00', new DateTimeZone('UTC'));
         static::assertNotFalse($dateTime);
         static::assertEquals(
             new DateValue($dateTime),
@@ -48,7 +48,7 @@ class DateValueTest extends TestCase {
             DateValue::fromValue('(D:2000010112000)'),
         );
 
-        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2020-09-30 15:43:07');
+        $dateTime = DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2020-09-30 15:43:07', new DateTimeZone('UTC'));
         static::assertNotFalse($dateTime);
         static::assertEquals(
             new DateValue($dateTime),


### PR DESCRIPTION
When trying to run the test suit on my system a couple of tests failed. This is because PDFs without a timezone return their time in local time (which is Europe/Berlin in my case) but the fixtures were created with a fixed UTC time zone. This makes sure tests run in UTC always.