### PR TITLE
Normalize simple-font glyph widths to em units

### DIFF
--- a/src/Document/Font/FontWidths.php
+++ b/src/Document/Font/FontWidths.php
@@ -10,6 +10,11 @@ readonly class FontWidths {
     ) {}
 
     public function getWidthForCharacter(int $characterCode): ?float {
-        return $this->widths[$characterCode - $this->firstChar] ?? null;
+        $width = $this->widths[$characterCode - $this->firstChar] ?? null;
+        if ($width === null) {
+            return null;
+        }
+
+        return $width / 1000;
     }
 }

--- a/src/Document/Object/Decorator/Font.php
+++ b/src/Document/Object/Decorator/Font.php
@@ -211,7 +211,7 @@ class Font extends DecoratedObject {
             }
         }
 
-        return 1000;
+        return 1.0;
     }
 
     /** @throws PdfParserException */

--- a/tests/Samples/files/issue-127/contents.yml
+++ b/tests/Samples/files/issue-127/contents.yml
@@ -12,7 +12,7 @@ modificationDate: 2025-06-11T10:39:03+02:00
 pages:
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       Kleine Anfrage zur schriftlichen Beantwortung  
       gemäß § 46 Abs. 1 GO LT 
@@ -29,7 +29,7 @@ pages:
       Antwort des Niedersächsischen Ministeriums für Inneres, Sport und Digitalisierung namens der 
       Landesregierung vom 06.06.2025 
        
-      Vorbemerkung der Abgeordneten 
+      Vorbemerkung der Abgeordneten  
       Einer aktuellen Meldung des Statistischen Bundesamtes zufolge sind die Schulden der deutschen 
       Städte und Gemeinden im vergangenen Jahr auf den höchsten Stand seit der deutschen Wiederver-
       einigung angestiegen.1 Demnach beträgt das Rekorddefizit 24,8 Milliarden Euro und ist vor allem auf 
@@ -63,7 +63,7 @@ pages:
       1 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       aus dem zuletzt geschaffenen Sondervermögen des Bundes 100 Milliarden Euro den Ländern und 
       Kommunen für Investitionen in die Infrastruktur zur Verfügung gestellt werden sollen. 
@@ -121,7 +121,7 @@ pages:
       2 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       der vorläufigen Ergebnisse der vierteljährlichen Kassenstatistik für das Jahr 2024 stellen dabei nicht 
       die Verschuldung der Kommunen in den Flächenländern dar. Der Finanzierungssaldo ergibt sich aus 
@@ -174,7 +174,7 @@ pages:
       3 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       4.  Welche  Gebietskörperschaften  haben  im  Jahr  2024  ein  Haushaltssicherungskonzept 
       vorgelegt, welche haben dies zum wiederholten Male ausgesetzt, und welche planen die 
@@ -222,11 +222,11 @@ pages:
       nähere Regelungen zu den Anteilen an den 100 Milliarden Euro, welche den Ländern aus dem Son-
       dervermögen auch für Investitionen zustehen sollen. Die Landesregierung wird sich auf Bund-Län-
                                                       
-      4   https://www.nsgb.de/infrastrukturpaket-ist-ein-bluff/ 
+      4   https://www.nsgb.de/infrastrukturpaket-ist-ein-bluff/  
       4 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       der-Ebene für die Belange des Landes und der Kommunen einsetzen. Zu den konkreten Auswirkun-
       gen auf die kommunalen Haushalte und den Landeshaushalt kann zum jetzigen Zeitpunkt allerdings 
@@ -273,19 +273,19 @@ pages:
       5 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
-       2025 2025 2025 2025 2025 
-      Stand der  Stand der  Neuverschul-Neuverschul-Neuverschul-
-      Liquiditäts-Investiven Kre-dung aus Li-dung aus In-dung  
-      kredite zum dite zum 31.12.  quiditätskre-vestiven Kre-Gesamt  
-      31.12. (in (in Euro) diten (in Euro) diten (in Euro) (in Euro) 
+        2025  2025  2025  2025  2025 
+      Stand der   Stand der   Neuverschul- Neuverschul- Neuverschul-
+      Liquiditäts- Investiven Kre- dung aus Li- dung aus In- dung  
+      kredite zum  dite zum 31.12.   quiditätskre- vestiven Kre- Gesamt  
+      31.12. (in  (in Euro)  diten (in Euro)  diten (in Euro)  (in Euro) 
       Euro) 
-      Landkreise  1.270.358.658 4.617.866.225 765.789.279 1.091.268.440 1.857.057.706 
+      Landkreise   1.270.358.658  4.617.866.225  765.789.279  1.091.268.440  1.857.057.706 
       (inkl. Region Hannover) 
-      kreisfreie Städte 761.073.331 2.480.644.184 378.746.300 594.858.753 973.605.053 
-      Samtgemeinden 130.713.017 1.620.984.765 69.467.661 531.689.985 656.063.367 
-      übrige kreis- und regionsange-2.340.267.449 11.670.868.874 969.709.424 2.668.659.337 3.657.566.844 
+      kreisfreie Städte  761.073.331  2.480.644.184  378.746.300  594.858.753  973.605.053 
+      Samtgemeinden  130.713.017  1.620.984.765  69.467.661  531.689.985  656.063.367 
+      übrige kreis- und regionsange- 2.340.267.449  11.670.868.874  969.709.424  2.668.659.337  3.657.566.844 
       hörige Gemeinden (Einheitsge-
       meinden inkl. große selbststän-
       dige Städte, Landeshauptstadt 
@@ -303,14 +303,14 @@ pages:
       § 172 NKomVG keine Intervention im Sinne eines Einschreitens der Kommunalaufsicht darstellt. 
       Im Jahr 2024 wurden in den folgenden fünf Fällen förmliche kommunalaufsichtliche Maßnahmen in 
       o. g. Sinne ergriffen: 
-      Kommune Kommunal- Rechts-Erläuterungen mit Angabe des Anlassgrundes 
-      aufsichtliche  grund-
-      Maßnahme lage 
+      Kommune  Kommunal-  Rechts- Erläuterungen mit Angabe des Anlassgrundes  
+      aufsichtliche   grund-
+      Maßnahme  lage 
        
-      Landkreis Beanstandung  § 173 Der Landkreis wurde vom Kreisausschuss beauf-
-      Celle Kreisaus-Abs. 1 tragt, ein Programm zur Förderung der kreisange-
-      schuss- NKomVG hörigen Städte und Gemeinden bei der Straßenun-
-      Beschluss terhaltung sowie -erneuerung zu erarbeiten und 
+      Landkreis  Beanstandung   § 173  Der Landkreis wurde vom Kreisausschuss beauf-
+      Celle  Kreisaus- Abs. 1  tragt, ein Programm zur Förderung der kreisange-
+      schuss-  NKomVG  hörigen Städte und Gemeinden bei der Straßenun-
+      Beschluss  terhaltung sowie -erneuerung zu erarbeiten und 
       das Programm dem Kreistag zur Beschlussfas-
       sung vorzulegen. Da der Landrat den Beschluss 
       des Kreisausschusses für rechtswidrig hielt, legte 
@@ -318,34 +318,34 @@ pages:
       dung gemäß § 88 Abs. 2 i. V. m. Abs. 1 Satz 6 
       NKomVG vor. Die Prüfung ergab, dass der Be-
       schluss des Kreisausschusses rechtswidrig war.  
-      Stadt  Beanstandung  § 173 Anforderungen des § 12 Abs. 2 der Kommunal-
-      Gifhorn Ratsbeschluss Abs. 1 haushalts- und -kassenverordnung (KomHKVO) 
-      NKomVG wurden nach Prüfung der Kommunalaufsichtsbe-
-       hörde nicht erfüllt. 
-      Mitglieds-Anordnung § 174  Weigerung des Hauptverwaltungsbeamten, einen 
-      gemeinde NKomVG Beschluss des Hauptausschusses umzusetzen. 
+      Stadt   Beanstandung   § 173  Anforderungen des § 12 Abs. 2 der Kommunal-
+      Gifhorn  Ratsbeschluss  Abs. 1  haushalts- und -kassenverordnung (KomHKVO) 
+      NKomVG  wurden nach Prüfung der Kommunalaufsichtsbe-
+        hörde nicht erfüllt. 
+      Mitglieds- Anordnung  § 174   Weigerung des Hauptverwaltungsbeamten, einen 
+      gemeinde  NKomVG  Beschluss des Hauptausschusses umzusetzen. 
       Holtland 
        
-      Gemeinde Beanstandung  § 173 Der Rat hat seinen Grundsatzbeschluss, den Neu-
-      Worpswede Aufhebung ei-Abs. 1 bau eines Schwimmbades nur bei einer Drittmittel-
-      nes Ratsbe-NKomVG finanzierung von 90 % umzusetzen, aufgehoben, 
-      schlusses  um den Neubau auch mit geringerer Drittmittelfi-
+      Gemeinde  Beanstandung   § 173  Der Rat hat seinen Grundsatzbeschluss, den Neu-
+      Worpswede  Aufhebung ei- Abs. 1  bau eines Schwimmbades nur bei einer Drittmittel-
+      nes Ratsbe- NKomVG  finanzierung von 90 % umzusetzen, aufgehoben, 
+      schlusses   um den Neubau auch mit geringerer Drittmittelfi-
       nanzierung umzusetzen. Die Kommunalaufsichts-
       behörde hat den Aufhebungsbeschluss aufgrund 
       6 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
-      Kommune Kommunal- Rechts-Erläuterungen mit Angabe des Anlassgrundes 
-      aufsichtliche  grund-
-      Maßnahme lage 
+      Kommune  Kommunal-  Rechts- Erläuterungen mit Angabe des Anlassgrundes  
+      aufsichtliche   grund-
+      Maßnahme  lage 
        
       eines Verstoßes gegen die Haushaltsgrundsätze 
       aus § 110 NKomVG beanstandet. 
-      Gemeinde Beanstandung § 173 Die Beanstandung erfolgte, weil die für eine Aus-
-      Lilienthal Stellenplan Abs. 1 weisung der Stelle in der vorgesehenen Entgelt-
-      NKomVG gruppe erforderlichen Voraussetzungen nicht mehr 
+      Gemeinde  Beanstandung  § 173  Die Beanstandung erfolgte, weil die für eine Aus-
+      Lilienthal  Stellenplan  Abs. 1  weisung der Stelle in der vorgesehenen Entgelt-
+      NKomVG  gruppe erforderlichen Voraussetzungen nicht mehr 
       vorlagen, weshalb die Ausweisung der Stelle einen 
       Verstoß gegen § 107 Abs. 2 NKomVG darstellte. 
        
@@ -394,7 +394,7 @@ pages:
       7 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       ausgestattet ist. Das Land Niedersachsen stellt dazu ab dem Jahr 2012 bis 2040 einen jährlichen 
       Finanzbeitrag von bis zu 35 Millionen Euro zur Rückführung dieser Kredite zur Verfügung. Das Ge-
@@ -448,7 +448,7 @@ pages:
       8 
   -
     content: |-
-      Niedersächsischer Landtag – 19. Wahlperiode Drucksache 19/7396 
+      Niedersächsischer Landtag – 19. Wahlperiode  Drucksache 19/7396 
        
       munen in einem Zeitraum von bis zu 30 Jahren gedeckt werden. Auch dazu liegen der Landesregie-
       rung aufgrund von fehlenden Jahresabschlüssen und Bilanzen keine hinreichenden Erkenntnisse für 
@@ -464,27 +464,27 @@ pages:
   -
     content: |-
       Tabelle 1: Schulden der niedersächsischen Gemeinden und Gemeindeverbände und deren Fonds, Einrichtungen und Unternehmen (FEU) 2023 und 2024 nach Art der Schulden in 1.000 Euro
-      20232024Veränderung 2023 zu 2024
-      GebietskörperschaftenGebietskörperschaftenGebietskörperschaften
-      Extra-sonstige Extra-sonstige 
-      Extra-sonstige 
+      2023 2024 Veränderung 2023 zu 2024
+      Gebietskörperschaften Gebietskörperschaften Gebietskörperschaften
+      Extra- sonstige  Extra- sonstige 
+      Extra- sonstige 
       Art der Schulden
-      kreisfreie Samt-kreisfreie Samt-2)2)kreisfreie Samt-2)2)
-      haushalteFEU
-      haushalteFEUhaushalteFEU
-      InsgesamtLandkreiseGemeindenInsgesamtLandkreiseGemeindenInsgesamtLandkreiseGemeinden
-      StädtegemeindenStädtegemeindenStädtegemeinden
-      in 1.000 Euroin Prozent
-      Schulden beim nicht-öffentlichen Bereich15.129.1663.406.2092.219.1961.082.6388.421.1241.622.57316.043.63517.478.2384.210.9942.554.3201.198.9109.514.014gg+15,5+23,6+15,1+10,7+13,0xx
-      davon Kassenkredite973.606169.622187.39325.376591.2156.398644.4271.754.857509.372375.94850.464819.072gg+80,2+200,3+100,6+98,9+38,5xx
-      davon Wertpapierschulden u. Kredite14.155.5603.236.5872.031.8031.057.2627.829.9091.616.17615.399.20815.723.3823.701.6222.178.3721.148.4468.694.942gg+11,1+14,4+7,2+8,6+11,0xx
+      kreisfreie  Samt- kreisfreie  Samt- 2) 2) kreisfreie  Samt- 2) 2)
+      haushalte FEU
+      haushalte FEU haushalte FEU
+      Insgesamt Landkreise Gemeinden Insgesamt Landkreise Gemeinden Insgesamt Landkreise Gemeinden
+      Städte gemeinden Städte gemeinden Städte gemeinden
+      in 1.000 Euro in Prozent
+      Schulden beim nicht-öffentlichen Bereich 15.129.166 3.406.209 2.219.196 1.082.638 8.421.124 1.622.573 16.043.635 17.478.238 4.210.994 2.554.320 1.198.910 9.514.014 g g +15,5 +23,6 +15,1 +10,7 +13,0 x x
+      davon Kassenkredite 973.606 169.622 187.393 25.376 591.215 6.398 644.427 1.754.857 509.372 375.948 50.464 819.072 g g +80,2 +200,3 +100,6 +98,9 +38,5 x x
+      davon Wertpapierschulden u. Kredite 14.155.560 3.236.587 2.031.803 1.057.262 7.829.909 1.616.176 15.399.208 15.723.382 3.701.622 2.178.372 1.148.446 8.694.942 g g +11,1 +14,4 +7,2 +8,6 +11,0 x x
       1)
-      Schulden beim öffentlichen Bereich961.50974.85114.42473.031799.2031.792.0884.475.4281.214.51793.98413.02448.4681.059.041gg+26,3+25,6-9,7-33,6+32,5xx
+      Schulden beim öffentlichen Bereich 961.509 74.851 14.424 73.031 799.203 1.792.088 4.475.428 1.214.517 93.984 13.024 48.468 1.059.041 g g +26,3 +25,6 -9,7 -33,6 +32,5 x x
       1)
-      davon Kassenkredite443.01223.9732.06428.936388.03832.928203.824586.89348.7502.0643.487532.591gg+32,5+103,4+0,0-87,9+37,3xx
-      davon Kredite518.49850.87812.36044.095411.1651.759.1604.271.604627.62445.23410.96044.981526.450gg+21,0-11,1-11,3+2,0+28,0xx
+      davon Kassenkredite 443.012 23.973 2.064 28.936 388.038 32.928 203.824 586.893 48.750 2.064 3.487 532.591 g g +32,5 +103,4 +0,0 -87,9 +37,3 x x
+      davon Kredite 518.498 50.878 12.360 44.095 411.165 1.759.160 4.271.604 627.624 45.234 10.960 44.981 526.450 g g +21,0 -11,1 -11,3 +2,0 +28,0 x x
       1)
-      Gesamtverschuldung16.090.6753.481.0602.233.6201.155.6689.220.3273.414.66220.519.06318.692.7554.304.9782.567.3441.247.37710.573.055gg+16,2+23,7+14,9+7,9+14,7xx
+      Gesamtverschuldung 16.090.675 3.481.060 2.233.620 1.155.668 9.220.327 3.414.662 20.519.063 18.692.755 4.304.978 2.567.344 1.247.377 10.573.055 g g +16,2 +23,7 +14,9 +7,9 +14,7 x x
       1) Nicht konsolidiert, enthält Doppelzählungen. Aufgrund der eingeschränkten Belastbarkeit und zur besseren Vergleichbarkeit der Angaben für 2023 und 2024. Darstellung ohne Schulden aus Cash-Pooling und der gemeinsamen Kassenbewirtschaftung der Samtgemeinden.
       2) Keine Angabe auf Grundlage der vierteljährlichen Kassenstatistik 2024 möglich. Angaben aus der Jährlichen Schuldenstatistik 2024 lagen zum Zeitpunkt der Erstellung der Tabelle noch nicht vor.
       Quelle: 2023 jährliche Schuldenstatistik, 2024 vierteljährliche kommunale Kassenstatistik 4. Quartal 2024

--- a/tests/Samples/files/issue-235/contents.yml
+++ b/tests/Samples/files/issue-235/contents.yml
@@ -13,310 +13,310 @@ pages:
   -
     content: |-
        
-      Niedersächsisches 
-      Gesetz- und Verordnungsblatt 
-      79. Jahrgang Hannover, den 10. April 2025 Nummer 25 
+      Niedersächsisches  
+      Gesetz-  und Verordnungsblatt 
+      79. Jahrgang  Hannover, den 10. April 2025  Nummer 25 
        
       Verordnung 
       zur Änderung der Feuerwehrverordnung 
       Vom 8. April 2025 
       Aufgrund  
-      des § 36 Nrn. 1 bis 3 des Niedersächsischen Brandschutzgesetzes vom 18. Juli 2012 (Nds. GVBl. S. 269), 
-      zuletzt geändert durch Artikel 1 des Gesetzes vom 6. November 2024 (Nds. GVBl. 2024 Nr. 91), und  
-      des § 115 Abs. 6 des Niedersächsischen Beamtengesetzes vom 25. März 2009 (Nds. GVBl. S. 72), zuletzt 
-      geändert durch Gesetz vom 6. November 2024 (Nds. GVBl. 2024 Nr. 93),  
+      des §  36 Nrn. 1 bis 3 des Niedersächsischen Brandschutzgesetzes vom 18.  Juli 2012 (Nds. GVBl. S. 269), 
+      zuletzt geändert durch Artikel  1 des Gesetzes vom 6. November 2024 (Nds. GVBl. 2024 Nr. 91), und  
+      des §  115 Abs. 6 des Niedersächsischen  Beamtengesetzes vom 25. März  2009 (Nds. GVBl. S. 72), zuletzt 
+      geändert durch Gesetz vom 6.  November 2024 (Nds. GVBl. 2024 Nr. 93),  
       wird verordnet: 
       Artikel 1 
-      Die Feuerwehrverordnung vom 30. April 2010 (Nds. GVBl. S. 185, 284), zuletzt geändert durch Verord-
-      nung vom 17. Mai 2011 (Nds. GVBl. S. 125), wird wie folgt geändert: 
-        1. Die Überschrift erhält folgende Fassung: 
-      Niedersächsische Feuerwehrverordnung (Nds. FwVO). 
-        2. Der Überschrift des Ersten Teils werden die Worte und Pflichtfeuerwehren angefügt. 
-        3. § 1 wird wie folgt geändert: 
-      a) In Absatz 1 wird die Angabe § 10 Abs. 2 durch die Angabe § 11 Abs. 4 ersetzt. 
-      b) In den Absätzen 2 und 3 werden jeweils in Satz 1 nach dem Wort Gemeinde die Worte ohne 
-      Berufsfeuerwehr eingefügt. 
-      c) Absatz 4 erhält folgende Fassung: 
+      Die Feuerwehrverordnung vom 30.  April  2010 (Nds. GVBl. S. 185, 284), zuletzt geändert durch  Verord-
+      nung vom 17. Mai 2011 (Nds. GVBl. S. 125), wird wie folgt geändert:  
+        1.   Die Überschrift erhält folgende Fassung:  
+      Niedersächsische Feuerwehrverordnung (Nds. FwVO) . 
+        2.   Der Überschrift des Ersten Teils werden die W orte  und Pflichtfeuerwehren angefügt.  
+        3.   § 1 wird wie folgt geändert:  
+      a)  In Absatz 1 wird die Angabe §  10 Abs. 2 durch die Angabe §  11 Abs. 4 ersetzt. 
+      b)  In den Absätzen  2 und 3 werden jeweils in Satz 1 nach dem Wort Gemeinde die Worte ohne 
+      Berufsfeuerwehr eingefügt.  
+      c)  Absatz 4 erhält folgende Fassung:  
       (4) Ist die in einer Gemeinde ohne Berufsfeuerwehr aufgestellte Freiwillige Feuerwehr oder 
       Pflichtfeuerwehr nicht in Ortsfeuerwehren gegliedert, so ist  
-      1. im Fall einer aufgestellten Freiwilligen Feuerwehr diese Feuerwehr und  
-      2. im Fall einer aufgestellten Pflichtfeuerwehr diese Feuerwehr 
-      mindestens als Stützpunktfeuerwehr einzurichten; Absatz 3 Satz 1 gilt entsprechend. 
-        4. § 2 wird wie folgt geändert:  
-      a) In Absatz 1 Satz 1 werden das Wort untergliederte durch das Wort gegliederte und das Wort 
+      1.  im Fall einer aufgestellten Freiwilligen Feuerwehr diese Feuerwehr und  
+      2.  im Fall einer aufgestellten Pflichtfeuerwehr diese Feuerwehr 
+      mindestens als Stützpunktfeuerwehr einzurichten; Absatz 3 Satz 1 gilt entsprechend.  
+        4.   § 2 wird wie folgt geändert:   
+      a)  In Absatz 1 Satz 1 werden das Wort untergliederte durch das Wort gegliederte und das Wort 
       gliedert durch die Worte oder Pflichtfeuerwehr gliedern ersetzt. 
        
-      Herausgeber: Niedersächsische Staatskanzlei 
+      Herausgeber: Niedersächsische Staatskanzlei  
     images:
       - page_0_image_0.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 2 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 2 
        
-      b) Absatz 2 erhält folgende Fassung:  
-      (2) 1Die taktischen Einheiten ,Selbständiger Truppʻ, ,Staffelʻ und ,Gruppeʻ sind mit Mitgliedern 
+      b)  Absatz 2 erhält folgende Fassung:   
+      (2) 1Die taktischen Einheiten , Selbständiger Truppʻ, ,Staffelʻ und ,Gruppeʻ  sind mit Mitgliedern 
       der Einsatzabteilung zu besetzen, deren Anzahl und wahrgenommene einsatzspezifische Funk-
       tionen wie folgt bestimmt sind: 
-      1. Selbständiger Trupp:  eine Truppführerin oder ein Truppführer,  
-          eine Maschinistin oder ein Maschinist und 
-       eine weitere einsatzspezifische Funktion im  
-      selbständigen Trupp,  
-      2. Staffel:    eine Staffelführerin oder ein Staffelführer,  
-          eine Maschinistin oder ein Maschinist,  
-      zwei Truppführerinnen oder Truppführer und 
-      zwei weitere einsatzspezifische Funktionen in der Staffel, 
-      3. Gruppe:    eine Gruppenführerin oder ein Gruppenführer,  
-           eine Maschinistin oder ein Maschinist,  
-           eine Melderin oder ein Melder,  
-           drei Truppführerinnen oder Truppführer und  
+      1.  Selbständiger Trupp:    eine Truppführerin oder ein Truppführer,   
+              eine Maschinistin oder ein Maschinist und 
+        eine weitere einsatzspezifische Funktion im  
+      selbständigen Trupp,   
+      2.  Staffel:       eine Staffelführerin oder ein  Staffelführer,   
+              eine Maschinistin oder ein Maschinist,  
+      zwei Truppführerinnen oder Truppführer und  
+      zwei weitere einsatzspezifische Funktionen in der Staffel,  
+      3.  Gruppe:       eine Gruppenführerin oder ein Gruppenführer,   
+                eine Maschinistin oder ein Maschinist,  
+                eine Melderin oder ein Melder,  
+                drei Truppführerinnen oder Truppführer und   
       drei weitere einsatzspezifische Funktionen in der Gruppe. 
-      2Der taktischen Einheit ,Zugʻ gehören ein Mitglied der Einsatzabteilung an, das die einsatzspezi-
-      fische Funktion Zugführerin oder Zugführer wahrnimmt, sowie als Teileinheiten des Zuges 
-      1. ein Zugtrupp, dem drei Mitglieder der Einsatzabteilung angehören, davon ein Mitglied als 
+      2Der taktischen Einheit , Zugʻ gehören ein Mitglied der Einsatzabteilung an, das die einsatzspezi-
+      fische Funktion Zugführerin oder Zugführer wahrnimmt, sowie als Teileinheiten des Zuges  
+      1.  ein Zugtrupp, dem drei Mitglieder der Einsatzabteilung angehören, davon ein Mitglied als 
       Führungsassistentin oder Führungsassistent, ein Mitglied als Melderin oder Melder und ein 
       Mitglied als Fahrerin oder Fahrer und 
-      2. taktische Einheiten nach Satz 1, und zwar 
-      a) zwei Gruppen (Variante 1),  
-      b) eine Gruppe, eine Staffel und ein selbständiger Trupp (Variante 2) oder  
-      c) eine Gruppe und drei selbständige Trupps (Variante 3). 
-      c) Absatz 3 erhält folgende Fassung: 
+      2.  taktische Einheiten nach Satz 1, und zwar 
+      a)  zwei Gruppen (Variante 1),  
+      b)  eine Gruppe, eine Staffel und ein selbständiger Trupp (Variante 2) oder   
+      c)  eine Gruppe und drei selbständige Trupps (Variante 3).  
+      c)  Absatz 3 erhält folgende Fassung:  
       (3) Die Absätze 1 und 2 gelten entsprechend für Einheiten der in Ortsfeuerwehren geglieder-
       ten Freiwilligen Feuerwehr oder Pflichtfeuerwehr und der Kreisfeuerwehr. 
-        5. § 3 wird wie folgt geändert: 
-      a) Absatz 2 Satz 1 Nr. 3 erhält folgende Fassung:  
-      3. die Anzahl der Mitglieder, die einsatzspezifische Funktionen in der nach Absatz 1 maßgeb-
+        5.   § 3 wird wie folgt geändert:  
+      a)  Absatz 2 Satz 1 Nr. 3 erhält folgende Fassung:   
+      3.  die Anzahl der Mitglieder, die einsatzspezifische Funktionen in der nach Absatz 1 maßgeb-
       lichen taktischen Einheit wahrnehmen, und.  
-      b) In Absatz 3 Satz 2 wird nach dem Wort besetzenden das Wort einsatzspezifischen eingefügt. 
-      c) In Absatz 4 werden nach den Worten Freiwillige Feuerwehr die Worte oder Pflichtfeuerwehr 
-      eingefügt. 
-        6. § 4 wird wie folgt geändert: 
-      a) Die Überschrift erhält folgende Fassung: 
+      b)  In Absatz 3 Satz 2 wird nach dem Wort besetzenden das Wort einsatzspezifischen eingefügt.  
+      c)  In Absatz 4 werden nach den Worten Freiwillige Feuerwehr die Worte oder  Pflichtfeuerwehr 
+      eingefügt.  
+        6.   § 4 wird wie folgt geändert:  
+      a)  Die Überschrift erhält folgende Fassung:  
       § 4 
-      Mindestausstattung und Mindestausrüstung. 
+      Mindestausstattung und Mindestausrüstung . 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 3 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 3 
        
-      b) Absatz 1 erhält folgende Fassung: 
+      b)  Absatz 1 erhält folgende Fassung:  
       (1) Die Typisierung und Mindestausstattung der in den Absätzen 2 bis 5 genannten Feuer-
-      wehrfahrzeuge von Gemeinden ohne Berufsfeuerwehr richten sich nach der Anlage 1. 
-      c) In Absatz 4 Satz 1 wird die Angabe § 2 Abs. 3 (Varianten 1 bis 3) durch die Angabe § 2 Abs. 2 
+      wehrfahrzeuge von Gemeinden ohne Berufsfeuerwehr richten sich nach der Anlage 1.  
+      c)  In Absatz 4 Satz 1 wird die Angabe § 2 Abs. 3 (Varianten 1 bis 3) durch die Angabe §  2 Abs. 2 
       Satz 2 Nr. 2 ersetzt. 
-      d) In Absatz 6 werden nach den Worten Freiwillige Feuerwehr die Worte oder Pflichtfeuerwehr 
-      eingefügt. 
-        7. § 5 wird gestrichen. 
-        8. Der bisherige § 6 wird § 5 und wie folgt geändert: 
-      a) In Absatz 1 werden nach den Worten Freiwilligen Feuerwehr die Worte oder der Pflichtfeuer-
-      wehr eingefügt. 
-      b) In Absatz 2 werden die Worte die örtlich zuständige Polizeidirektion durch die Worte das für 
-      Inneres zuständige Ministerium oder die von ihm bestimmte Landesbehörde ersetzt. 
-        9. Der Zweite und Dritte Teil erhalten folgende Fassung: 
+      d)  In Absatz 6 werden nach den Worten Freiwillige Feuerwehr die Worte oder Pflichtfeuerwehr 
+      eingefügt.  
+        7.   § 5 wird gestrichen. 
+        8.   Der bisherige §  6 wird §  5 und wie folgt geändert:  
+      a)  In Absatz 1 werden nach den Worten Freiwilligen Feuerwehr die Worte oder der Pflichtfeuer-
+      wehr eingefügt.  
+      b)  In Absatz 2 werden die Worte die örtlich zuständige Polizeidirektion durch die Worte das für 
+      Inneres zuständige Ministerium oder die von  ihm bestimmte Landesbehörd e ersetzt. 
+        9.   Der Zweite und Dritte Teil erh alten folgende Fassung: 
       Zweiter Teil 
       Ausbildung nach Eintritt in die Einsatzabteilung, 
-      Übertragung von Funktionen und Verleihung von Dienstgraden 
-      bei der Freiwilligen Feuerwehr und der Pflichtfeuerwehr 
+      Übertragung von Funktionen und Verleihung von Dienstgraden  
+      bei der Freiwilligen Feuerwehr und der Pflichtfeuerwehr  
       § 6 
       Gliederung der Ausbildung 
       Die Ausbildung der Mitglieder der Freiwilligen Feuerwehr und der Pflichtfeuerwehr gliedert sich in 
-      1. die modulare Grundlagenausbildung, 
-      2. die technische Ausbildung und 
-      3. die Führungsausbildung. 
+      1.  die modulare Grundlagenausbildung, 
+      2.  die technische Ausbildung und 
+      3.  die Führungsausbildung.  
       § 7 
       Modulare Grundlagenausbildung 
       (1) 1Die Teilnahme an der modularen Grundlagenausbildung ist für Mitglieder der Einsatzabteilung 
       der Freiwilligen Feuerwehr und der Pflichtfeuerwehr verpflichtend mit Ausnahme derjenigen Mitglieder, 
       die als Feuerwehr-Fachberaterin oder Feuerwehr-Fachberater aufgrund besonderer Kenntnisse und 
-      Fähigkeiten die Einsatzabteilung beraten. 2Mitglieder der Einsatzabteilung müssen innerhalb von 
+      Fähigkeiten die Einsatzabteilung beraten.  2Mitglieder der Einsatzabteilung müssen innerhalb von 
       drei Jahren seit dem Eintritt in die Einsatzabteilung die Ausbildung zum Truppmitglied abschließen. 
-      3Schließt ein Mitglied die Ausbildung zum Truppmitglied innerhalb dieser Zeit nicht ab, so ist es aus der 
+      3Schließt ein Mitglied die A usbildung zum Truppmitglied innerhalb dieser Zeit nicht ab, so ist es aus der 
       Einsatzabteilung zu entlassen, es sei denn sie oder er hat die Ausbildung aufgrund einer Krankheit oder 
-      eines sonstigen Grundes, den sie oder er nicht zu vertreten hat, nicht abgeschlossen.  
+      eines sonstigen Grundes, den sie oder er nicht zu vertreten hat, nicht abgeschlossen.   
       (2) 1Die modulare Grundlagenausbildung gliedert sich in die Ausbildung zum Erreichen der Einsatz-
       fähigkeit, die Ausbildung zum Truppmitglied und die Ausbildung zur Truppführerin oder zum Truppfüh-
       rer. 2Voraussetzung für die Ausbildung zum Truppmitglied ist eine abgeschlossene Ausbildung zum 
       Erreichen der Einsatzfähigkeit und für die Ausbildung zur Truppführerin oder zum Truppführer eine ab-
       geschlossene Ausbildung zum Truppmitglied.  
-      (3) Die Ausbildung zum Erreichen der Einsatzfähigkeit soll den Mitgliedern der Freiwilligen Feuer-
-      wehr oder der Pflichtfeuerwehr die Fähigkeiten, Fertigkeiten und Kompetenzen zur angeleiteten Mitwir-
+      (3) Die Ausbildung zum Erreichen der Einsatzfähigkeit soll den Mi tgliedern der Freiwilligen Feuer-
+      wehr oder der  Pflichtfeuerwehr die Fähigkeiten, Fertigkeiten und Kompetenzen zur angeleiteten Mitwir-
       kung in der Einsatzabteilung vermitteln.  
       (4) Die Ausbildung zum Truppmitglied soll den Mitgliedern der Einsatzabteilung die Fähigkeiten, Fer-
       tigkeiten und Kompetenzen zur nicht angeleiteten Mitwirkung in einem nicht selbständigen Trupp ver-
       mitteln.  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 4 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 4 
        
       (5) Die Ausbildung zur Truppführerin oder zum Truppführer soll den Mitgliedern die Fähigkeiten, 
-      Fertigkeiten und Kompetenzen zur Führung eines nicht selbständigen Trupps vermitteln. 
-      (6) Die modulare Grundlagenausbildung wird durch die Gemeinden und Landkreise nach den Num-
-      mern 1.1.1. bis 1.1.10 des Runderlasses ,Ausbildung der Freiwilligen Feuerwehren; Feuerwehr-Dienst-
-      vorschrift 2ʻ des Ministeriums für Inneres und Sport vom 17. November 2023 (Nds. MBl. S. 974  im 
-      Folgenden: Erlass-FwDV 2) durchgeführt mit den Basis- und Ergänzungsmodulen nach den Num-
-      mern 1.2.1 bis 1.2.1.4 Erlass-FwDV 2 und mit dem Kompetenznachweis nach Nummer 1.2.1.5 Erlass-
+      Fertigkeiten und Kompetenzen zur Führung eines nicht selbständigen Trupps vermitteln.  
+      (6) Die modulare Grundlagenausbildung wird durch die Gemeinden und Landkreise nach den  Num-
+      mern 1.1.1. bis 1.1.10 des Runderlasses , Ausbildung der Freiwilligen Feuerwehren; Feuerwehr-Dienst-
+      vorschrift 2ʻ des Ministeriums für Inneres und Sport vom 17.  November 2023 (Nds. MBl.  S. 974   im 
+      Folgenden: Erlass-FwDV 2) durchgeführt mit den Basis - und Ergänzungsmodulen nach den  Num-
+      mern  1.2.1 bis 1.2.1.4 Erlass-FwDV 2 und mit  dem Kompetenznachweis nach Nummer 1.2.1.5 Erlass -
       FwDV 2 abgeschlossen. 
       § 8 
       Technische Ausbildung 
       (1) 1Voraussetzung für die technische Ausbildung ist der Abschluss der modularen Grundlagenaus-
-      bildung. 2Sie wird mit den Ausbildungslehrgängen nach den Nummern 3.1 bis 3.9 Anlage 1 Erlass-
-      FwDV 2, insbesondere den Ausbildungslehrgängen ,Atemschutzgeräteträgerʻ, ,Gerätewarteʻ, ,Atem-
-      schutzgerätewarteʻ, ,Maschinistenʻ, ,Sprechfunkerʻ, ,Technische Hilfeleistungʻ und ,ABC-Einsatzʻ durch-
-      geführt. 3Die technische Ausbildung wird mit dem Leistungsnachweis nach Nummer 1.8 Anlage 1 Er-
-      lass-FwDV 2 abgeschlossen. 4Aufbauend auf dem Ausbildungslehrgang ,Atemschutzgeräteträgerʻ kön-
-      nen die technischen Ausbildungslehrgänge ,Atemschutzbeauftragteʻ und ,Chemikalienschutzanzugträ-
+      bildung. 2Sie wird mit den Ausbildungslehrgängen nach den Nummern 3.1 bis 3.9 Anlage 1 Erlass -
+      FwDV 2, insbesondere den Ausbildungslehrgängen , Atemschutzgeräteträgerʻ, ,Gerätewarteʻ , ,Atem-
+      schutzgerätewarteʻ , ,Maschinistenʻ , ,Sprechfunkerʻ, ,Technische Hilfeleistungʻ und ,ABC-Einsatzʻ durch-
+      geführt.  3Die technische Ausbildung wird mit dem Leistungsnachweis nach Nummer 1.8 Anlage  1 Er-
+      lass-FwDV 2 abgeschlossen. 4Aufbauend auf dem Ausbildungslehrgang , Atemschutzgeräteträgerʻ kön-
+      nen die technischen Ausbildungslehrgänge , Atemschutzbeauftragteʻ und ,Chemikalienschutzanzugträ-
       gerʻ nach dem Runderlass ,Einsatz- und Ausbildungsanleitungen für Feuerwehren; Atemschutz (Feuer-
       wehr-Dienstvorschrift 7)ʻ des Ministeriums für Inneres und Sport vom 21. Oktober 2022 (Nds. MBl. 
-      S. 1421  im Folgenden: FwDV 7) durchgeführt werden. 5Aufbauend auf dem Ausbildungslehrgang 
-      ,Maschinistenʻ kann der Ausbildungslehrgang ,Gerätebeauftragteʻ durchgeführt werden.  
+      S. 1421   im Folgenden: FwDV 7) durchgeführt werden.  5Aufbauend auf dem Ausbildungslehrgang 
+      ,Maschinistenʻ  kann der Ausbildungslehrgang , Gerätebeauftragteʻ  durchgeführt werden.  
       (2) 1Die technische Ausbildung soll den Mitgliedern der Einsatzabteilung durch Einsatzübungen und 
       Ausbildungslehrgänge die für die jeweilige Aufgabe im Einsatz erforderlichen Fähigkeiten, Fertigkeiten 
       und Kompetenzen vermitteln. 2Die Einsatzübungen sind so zu gestalten, dass die Mitglieder künftige 
       Einsatzanforderungen beherrschen. 
-      (3) 1Die Ausbildungslehrgänge ,Maschinistenʻ, ,Atemschutzgeräteträgerʻ und ,Sprechfunkerʻ werden 
-      durch die Landkreise durchgeführt. 2Die Ausbildungslehrgänge ,Atemschutzbeauftragteʻ, ,Gerätebeauf-
+      (3) 1Die Ausbildungslehrgänge  ,Maschinistenʻ , ,Atemschutzgeräteträgerʻ und ,Sprechfunkerʻ werden 
+      durch die Landkreise durchgeführt.  2Die Ausbildungslehrgänge , Atemschutzbeauftragteʻ , ,Gerätebeauf-
       tragteʻ und ,Chemikalienschutzanzugträgerʻ werden durch die Gemeinden und die Landkreise durchge-
-      führt. 3Die sonstigen Ausbildungslehrgänge werden durch das Niedersächsische Landesamt für Brand- 
-      und Katstrophenschutz durchgeführt. 4Die Landkreise können die Ausbildungslehrgänge ,Technische 
+      führt.  3Die sonstigen Ausbildungslehrgänge werden durch das Niedersächsische Landesamt für Brand-  
+      und Katstrophenschutz durchgeführt.  4Die Landkreise können die Ausbildungslehrgänge  ,Technische 
       Hilfeleistungʻ und ,ABC-Einsatzʻ ebenfalls durchführen, wenn dies mit dem Niedersächsischen Landes-
-      amt für Brand- und Katastrophenschutz vereinbart ist.  
+      amt für Brand-  und Katastrophenschutz vereinbart ist.  
       § 9 
-      Führungsausbildung 
+      Führungsausbildung  
       (1) 1Die Führungsausbildung gliedert sich in die Ausbildung zur Gruppenführerin oder zum Gruppen-
-      führer, zur Zugführerin oder zum Zugführer sowie zur Verbandsführerin oder zum Verbandsführer. 2Die 
+      führer, zur Zugführerin oder zum Zugführer sowie zur Verbandsführerin oder zum Verbandsführer.  2Die 
       Ausbildung zum Gruppenführer kann durch die Ausbildung zur Leiterin oder zum Leiter einer Freiwilligen 
-      Feuerwehr oder Pflichtfeuerwehr, zum Führen im ABC-Einsatz (Ausbildungslehrgang ,Führen im ABC-
+      Feuerwehr oder Pflichtfeuerwehr, zum Führen im ABC -Einsatz (Ausbildungslehrgang , Führen im ABC -
       Einsatzʻ) oder zur Ausbilderin oder zum Ausbilder in der Freiwilligen Feuerwehr oder Pflichtfeuerwehr 
-      (Ausbildungslehrgang ,Ausbilder in der Feuerwehrʻ) ergänzt werden. 3Die Ausbildung zum Zugführer 
-      kann durch die Ausbildung zur Stabsarbeit (Ausbildungslehrgang ,Einführung in die Stabsarbeitʻ) er-
-      gänzt werden.  
-      (2) 1Voraussetzung für die Ausbildung zur Gruppenführerin oder zum Gruppenführer ist die abge-
-      schlossene Ausbildung zur Truppführerin oder zum Truppführer. 2Die Ausbildung erfolgt in einem Aus-
-      bildungslehrgang (Ausbildungslehrgang ,Gruppenführerʻ). 3Der Ausbildungslehrgang ,Gruppenführerʻ 
+      (Ausbildungslehrgang ,Ausbilder in der Feuerwehrʻ) ergänzt werden.  3Die Ausbildung zum Zugführer 
+      kann durch die Ausbildung zur Stabsarbeit (Ausbildungslehrgang  ,Einführung in die Stabsarbeitʻ) er-
+      gänzt werden.   
+      (2) 1Voraussetzung für die Ausbildung zur Gruppenführerin oder zum  Gruppenführer ist die abge-
+      schlossene Ausbildung zur Truppführerin oder zum Truppführer.  2Die Ausbildung erfolgt in einem Aus-
+      bildungslehrgang (Ausbildungslehrgang  ,Gruppenführerʻ). 3Der Ausbildungslehrgang  ,Gruppenführerʻ 
       soll die Befähigung zum Führen einer Gruppe, einer Staffel oder eines selbständigen Trupps und zur 
-      Leitung von Einsätzen mit höchstens neun Mitgliedern der Einsatzabteilung vermitteln.  
+      Leitung von Einsätzen mit höchstens neun Mitgliedern der Einsatzabteilung vermitteln.   
       (3) 1Voraussetzung für die Ausbildung zur Zugführerin oder zum Zugführer ist der Abschluss des 
-      Ausbildungslehrgangs ,Gruppenführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungslehrgang 
+      Ausbildungslehrgangs  ,Gruppenführerʻ.  2Die Ausbildung erfolgt in einem Ausbildungslehrgang 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 5 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 5 
        
       (Ausbildungslehrgang ,Zugführerʻ). 3Der Ausbildungslehrgang ,Zugführerʻ soll die Befähigung zum Füh-
       ren eines Zuges, und zur Leitung von Einsätzen mit höchstens 22 Mitgliedern der Einsatzabteilung ver-
       mitteln. 
-      (4) 1Voraussetzung für die Ausbildung zur Verbandsführerin oder zum Verbandsführer ist der Ab-
+      (4) 1Voraussetzung für die Ausbildung zur Verbandsführerin oder zum Verbandsführer ist d er Ab-
       schluss des Ausbildungslehrgangs ,Zugführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungslehrgang 
-      (Ausbildungslehrgang ,Verbandsführerʻ). 3Der Ausbildungslehrgang ,Verbandsführerʻ soll die Befähi-
+      (Ausbildungslehrgang ,Verbandsführerʻ). 3Der Ausbildungslehrgang , Verbandsführerʻ soll die Befähi-
       gung zum Führen mehrerer taktischer Einheiten, denen zusammen mindestens 23 Mitglieder einer Ein-
       satzabteilung angehören und zur Leitung von Einsätzen, bei denen gleichzeitig Aufgaben aus mehreren 
       Bereichen, insbesondere dem abwehrenden Brandschutz, der Hilfeleistung, den Fachdiensten im Ka-
-      tastrophenschutz oder dem Rettungsdienst, erfüllt werden, vermitteln.  
+      tastrophenschutz oder dem Rettungsdienst, erfüllt werden, vermitteln.   
       (5) 1Voraussetzung für die Ausbildung zur Leiterin oder zum Leiter einer Freiwilligen Feuerwehr oder 
-      Pflichtfeuerwehr ist der Abschluss des Ausbildungslehrgangs ,Gruppenführerʻ. 2Die Ausbildung erfolgt 
-      in einem Ausbildungslehrgang (Ausbildungslehrgang ,Leiter einer Feuerwehrʻ). 3Der Ausbildungslehr-
+      Pflichtfeuerwehr ist der Abschluss des Ausbildungslehrgangs , Gruppenführerʻ. 2Die Ausbildung erfolgt 
+      in einem Ausbildungslehrgang (Ausbildungslehrgang  ,Leiter einer Feuerwehrʻ). 3Der Ausbildungslehr-
       gang ,Leiter einer Feuerwehrʻ soll die organisatorischen Fähigkeiten und erforderlichen Verwaltungs-
       kenntnisse zur Leitung einer Freiwilligen Feuerwehr oder Pflichtfeuerwehr vermitteln.  
-      (6) 1Voraussetzung für die Ausbildung zum Führen im ABC-Einsatz ist der Abschluss des Ausbil-
+      (6) 1Voraussetzung für die Ausbildung zum Führen im ABC -Einsatz ist der Abschluss des Ausbil-
       dungslehrgangs ,Gruppenführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungslehrgang (Ausbildungs-
-      lehrgang ,Führen im ABC-Einsatzʻ). 3Der Ausbildungslehrgang ,Führen im ABC-Einsatzʻ soll die Befä-
-      higung zum taktisch richtigen Einsatz der ABC-Ausrüstung und zum Führen von im Einsatz mit ABC-
-      Ausrüstung ausgebildeten Mitgliedern der Einsatzabteilung vermitteln. 
+      lehrgang ,Führen im ABC -Einsatzʻ). 3Der Ausbildungslehrgang  ,Führen im ABC -Einsatzʻ soll die Befä-
+      higung zum taktisch richtigen Einsatz der ABC -Ausrüstung und zum Führen von im Einsatz mit ABC -
+      Ausrüstung ausgebildeten Mitgliedern der Einsatzabteilung vermitteln.  
       (7) 1Voraussetzung für die Ausbildung zur Ausbilderin oder zum Ausbilder in der Feuerwehr ist der 
-      Abschluss des Ausbildungslehrgangs ,Gruppenführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungs-
+      Abschluss des Ausbildungslehrgangs  ,Gruppenführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungs-
       lehrgang (Ausbildungslehrgang ,Ausbilder in der Feuerwehrʻ). 3Der Ausbildungslehrgang ,Ausbilder in 
       der Feuerwehrʻ soll die Befähigung zur Durchführung der auf Ebene einer Gemeinde oder eines Land-
-      kreises stattfindenden Lehrgänge vermitteln. 
-      (8) 1Voraussetzung für die Ausbildung zur Stabsarbeit ist der Abschluss des Ausbildungslehrgangs 
-      ,Zugführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungslehrgang (Ausbildungslehrgang ,Einführung in 
-      die Stabsarbeitʻ). 3Der Ausbildungslehrgang ,Einführung in die Stabsarbeitʻ soll die Befähigung zum 
-      selbständigen Führen eines Sachgebietes in einer stabsmäßig arbeitenden Einsatzleitung vermitteln. 
-      (9) 1Die Führungsausbildung wird durch das Niedersächsische Landesamt für Brand- und Katastro-
-      phenschutz nach den Nummern 4.1 bis 4.7 Anlage 1 Erlass-FwDV 2 durchgeführt. 2Die Führungsaus-
+      kreises stattfindenden Lehrgänge vermitteln.  
+      (8) 1Voraussetzung für die Ausbildung zur Stabsarbeit ist der Abschluss des Ausbil dungslehrgangs 
+      ,Zugführerʻ. 2Die Ausbildung erfolgt in einem Ausbildungslehrgang (Ausbildungslehrgang , Einführung in 
+      die Stabsarbeitʻ). 3Der Ausbildungslehrgang , Einführung in die Stabsarbeitʻ soll die Befähigung zum 
+      selbständigen Führen eines Sachgebietes  in einer stabsmäßig arbeitenden Einsatzleitung  vermitteln. 
+      (9) 1Die Führungsausbildung wird durch das Niedersächsische Landesamt für Brand-  und Katastro-
+      phenschutz nach den  Nummern 4.1 bis 4.7 Anlage 1 Erlass-FwDV 2 durchgeführt.  2Die Führungsaus-
       bildung wird mit dem Leistungsnachweis nach Nummer 1.8 Anlage 1 Erlass-FwDV 2 abgeschlossen. 
       § 10  
       Übertragung von Funktionen 
       (1) 1Die in der Anlage 2 Teile A und B genannten Regelfunktionen werden den ehrenamtlichen Füh-
-      rungskräften nach den §§ 20 bis 22 NBrandSchG und den weiteren Mitgliedern der Freiwilligen Feuer-
-      wehr oder Pflichtfeuerwehr übertragen, wenn sie persönlich und fachlich geeignet sind. 2Die fachliche 
-      Eignung liegt vor, wenn das Mitglied die der zu übertragenden Regelfunktion in der Anlage 2 Teile A 
-      und B zugeordneten Ausbildungen oder Ausbildungslehrgänge abgeschlossen hat und in Fällen der 
-      ehrenamtlichen Führungskräfte nach den §§ 20 bis 22 NBrandSchG die der zu übertragenden Regel-
+      rungskräften nach den  §§ 20 bis 22  NBrandSchG und den weiteren Mitgliedern der Freiwilligen Feuer-
+      wehr oder Pflichtfeuerwehr übertragen, wenn sie persönlich und fachlich geeignet sind.  2Die fachliche 
+      Eignung liegt vor, wenn das Mitglied die der zu übertragenden Regelfunktion in der Anlage  2 Teile A 
+      und B zugeordneten Ausbildungen oder Ausbildungslehrgänge abgeschlossen hat und  in Fällen der 
+      ehrenamtlichen Führungskräfte nach den §§ 20 bis 22 NBrandSchG  die der zu übertragenden Regel-
       funktion nach Anlage 2 Teil B zugeordnete Mindestdienstzeit und Gesamtdienstzeit absolviert hat.  
       (2) 1Steht ein fachlich geeignetes Mitglied nach Absatz 1 nicht zur Verfügung, so kann einem Mitglied 
-      der Einsatzabteilung eine Regelfunktion abweichend von Absatz 1 für längstens zwei Jahre zur kom-
+      der Einsatzabteilung eine Regelfunktion abweichend von Absatz  1 für längstens zwei Jahre zur kom-
       missarischen Wahrnehmung übertragen werden, wenn das Mitglied für die Ausbildung oder den Aus-
-      bildungslehrgang, die oder der für die Übertragung der Regelfunktion erforderlich ist, angemeldet ist, an 
-      dieser oder diesem teilnimmt oder alsbald teilnimmt. 2Schließt das Mitglied die Ausbildung oder den 
+      bildungslehrgang, die oder der für die Übertragung der Regelfunktion erforderlic h ist, angemeldet ist, an 
+      dieser oder diesem teilnimmt oder alsbald teilnimmt.  2Schließt das Mitglied die Ausbildung oder den 
       Ausbildungslehrgang aufgrund einer Krankheit oder eines sonstigen Grundes, den es nicht zu vertreten 
       hat, nicht innerhalb von zwei Jahren seit Beginn der Ausbildung oder des Ausbildungslehrgangs ab, so 
       kann der Träger der Feuerwehr den Zeitraum der kommissarischen Wahrnehmung der Regelfunktion 
-      einmalig um längstens zwei weitere Jahre verlängern. 3Der Träger der Feuerwehr hat darauf 
+      einmalig um längstens zwei weitere Jahre verlängern.  3Der Träger der Feuerwehr hat darauf 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 6 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 6 
        
       hinzuwirken, dass die Ausbildung oder der Ausbildungslehrgang nach Wegfall des Grundes nach Satz 2 
-      unverzüglich nachgeholt werden. 4Die Zeiten einer kommissarischen Wahrnehmung einer Regelfunk-
-      tion sind nicht Amtszeit nach § 20 Abs. 4 Satz 1, § 21 Abs. 3 Satz 1 und § 22 Abs. 2 Satz 1 NBrand-
+      unverzüglich nachgeholt werden.  4Die Zeiten einer kommissarischen Wahrnehmung einer Regelfunk-
+      tion sind nicht Amtszeit nach §  20 Abs. 4 Satz 1, §  21 Abs. 3 Satz 1 und §  22 Abs. 2 Satz 1 NBrand-
       SchG. 
-      (3) Hat das Mitglied die erforderliche Mindestdienstzeit oder Gesamtdienstzeit nicht absolviert, so 
+      (3) Hat das Mitglied die erforderliche Mindestdienstzeit oder Gesamtdienstzeit nicht absolvi ert, so 
       kann der Träger der Feuerwehr im Einvernehmen mit dem für Inneres zuständigen Ministerium die Re-
-      gelfunktionen Abschnittsleiterin oder Abschnittsleiter, stellvertretende Abschnittsleiterin oder stellvertre-
+      gelfunktionen Abschnittsleiterin oder Abschnittsleiter, stellvertretende Abschnittsleiterin oder s tellvertre-
       tender Abschnittsleiter, stellvertretende Stadtbrandmeisterin oder stellvertretender Stadtbrandmeister in 
       Städten mit Berufsfeuerwehr, stellvertretende Stadtbrandmeisterin oder stellvertretender Stadtbrand-
-      meister in kreisfreien Städten ohne Berufsfeuerwehr, Stadtbrandmeisterin oder Stadtbrandmeister in 
+      meister in kreisfreien Städten ohne Berufsfeuerwehr, Stadtbrandmeisterin oder Stadtbrandmeister  in 
       Städten mit Berufsfeuerwehr, Kreisbrandmeisterin oder Kreisbrandmeister und stellvertretende Kreis-
       brandmeisterin oder stellvertretender Kreisbrandmeister, Stadtbrandmeisterin oder Stadtbrandmeister 
-      in kreisfreien Städten ohne Berufsfeuerwehr und Regierungsbrandmeisterin oder Regierungsbrand-
+      in kreisfreien Städten ohne Berufsfeuerwehr und Regier ungsbrandmeisterin oder Regierungsbrand-
       meister abweichend von Absatz 1 Satz 2 übertragen, wenn das Mitglied über eine gleichwertige Berufs-
       erfahrung in der Personalführung, Organisation und Steuerung eines Arbeitsbereichs sowie über ver-
-      tiefte Kenntnisse über den Aufbau und die Organisation der öffentlichen Verwaltung verfügt. 
+      tiefte Kenntnisse über den Aufbau und die Organisation der öffentlichen Verwaltung verfügt.  
       (4) 1Die in der Anlage 2 Teil C genannten einsatzspezifischen Funktionen werden Mitgliedern der 
-      Einsatzabteilung zur Wahrnehmung im Einsatz übertragen, wenn sie fachlich geeignet sind. 2Die fach-
-      liche Eignung liegt vor, wenn das Mitglied die in der Anlage 2 Teil C genannten Ausbildungen oder 
-      Ausbildungslehrgänge abgeschlossen hat. 
-      (5) 1Ehrenamtliche Führungskräfte nach den §§ 20 bis 22 NBrandSchG und weitere Mitglieder der 
-      Freiwilligen Feuerwehr oder Pflichtfeuerwehr, denen eine Regelfunktion nach Absatz 1 oder eine Re-
+      Einsatzabteilung zur Wahrnehmung im Einsatz übertragen, wenn sie fachlich geeignet sind.  2Die fach-
+      liche Eignung liegt vor, wenn das Mitglied die in der Anlage  2 Teil C genannten Ausbildungen oder 
+      Ausbildungslehrgänge abgeschlossen hat.  
+      (5) 1Ehrenamtliche Führungskräfte nach  den §§ 20 bis 22 NBrandSchG und weitere Mitglieder der 
+      Freiwilligen Feuerwehr oder Pflichtfeuerwehr, denen eine Regelfunktion nach Absatz  1 oder eine Re-
       gelfunktion zur kommissarischen Wahrnehmung nach Absatz 2 übertragen wurde, können vom Träger 
-      der Feuerwehr aus dieser Regelfunktion abberufen werden, wenn ein wichtiger Grund vorliegt. 2Ein 
+      der Feuerwehr aus dieser Regelfunktion abberufen werden, wenn ein wichtiger Grund vorliegt.  2Ein 
       wichtiger Grund liegt insbesondere vor, wenn das Mitglied 
-      1. die Dienstpflichten vorsätzlich oder grob fahrlässig verletzt hat, 
-      2. das Ansehen der Feuerwehr vorsätzlich oder grob fahrlässig geschädigt hat, 
-      3. den Zusammenhalt innerhalb der Gemeinschaft der Feuerwehr durch sein Verhalten vorsätzlich 
-      oder grob fahrlässig erheblich gestört hat oder 
-      4. die Tätigkeit aus gesundheitlichen oder persönlichen Gründen nicht mehr ordnungsgemäß aus-
-      üben kann. 
+      1.  die Dienstpflichten vorsätzlich oder grob fahrlässig verletzt hat,  
+      2.  das Ansehen der Feuerwehr vorsätzlich oder grob fahrlässig geschädigt hat,  
+      3.  den Zusammenhalt innerhalb der Gemeinschaft der Feuerwehr durch sein  Verhalten vorsätzlich 
+      oder grob fahrlässig erheblich gestört hat oder  
+      4.  die Tätigkeit aus gesundheitlichen oder persönlichen Gründen nicht mehr ordnungsgemäß aus-
+      üben kann.  
       § 11 
-      Dienstgrade, Voraussetzungen für die Verleihung von Dienstgraden, Verfahren 
+      Dienstgrade, Voraussetzungen für die Verleihung von Dienstgraden, Verfahren  
       (1) Die Bezeichnung der Dienstgrade der Freiwilligen Feuerwehr und der Pflichtfeuerwehr, die Ab-
-      kürzung der Dienstgrade, die Zuordnung dieser Dienstgrade zu Stufen innerhalb von Dienstgradgrup-
-      pen (Dienstgradstufen) und die Abfolge der Dienstgradgruppen sind in Anlage 3 geregelt.  
-      (2) 1Die in Anlage 3 Teile A und B jeweils Spalte 2 bezeichneten Dienstgrade werden einem Mitglied 
-      der Einsatzabteilung der Freiwilligen Feuerwehr oder Pflichtfeuerwehr verliehen, wenn es persönlich 
+      kürzung der Dienstgrade, die Zuordnung dieser Dienstgrade zu Stufen innerhalb von Die nstgradgrup-
+      pen (Dienstgradstufen) und die Abfolge der Dienstgradgruppen sind in Anlage 3  geregelt.  
+      (2) 1Die in Anlage 3 Teile  A und B jeweils Spalte 2 bezeichneten Dienstgrade werden einem Mitglied 
+      der Einsatzabteilung der Freiwilligen Feuerwehr oder Pfli chtfeuerwehr verliehen, wenn es persönlich 
       geeignet ist und  
-      1. es die dem Dienstgrad in der Anlage 3 Teil A zugeordnete und erforderliche Ausbildung abge-
-      schlossen hat und nach deren Abschluss die in Anlage 3 Teil A dem Dienstgrad zugeordnete 
-      Mindestdienstzeit für die Verleihung dieses Dienstgrades absolviert hat oder 
-      2. ihm eine Regelfunktion nach Anlage 3 Teil B übertragen worden ist.  
+      1.  es die dem Dienstgrad in der Anlage  3 Teil A zugeordnete und erforderliche Ausbildung abge-
+      schlossen hat und nach deren Abschluss die in Anlage  3 Teil A dem Dienstgrad zugeordnete 
+      Mindestdienstzeit für die Verleihung dieses Dienstgrades absolviert hat oder  
+      2.  ihm eine Regelfunktion nach Anlage  3 Teil B übertragen worden ist.   
       2Zeiten, in denen die Mitgliedschaft zeitweilig ruht (§ 12 Abs. 5 NBrandSchG), werden nicht auf die 
       Mindestdienstzeit nach Satz 1 Nr. 1 angerechnet. 3Die Verleihung eines Dienstgrades hat innerhalb von 
       24 Monaten zu erfolgen, nachdem das Mitglied die Voraussetzungen für die Verleihung des Dienstgra-
-      des erfüllt. 
+      des erfüllt.  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 7 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 7 
        
-      (3) 1Die in Anlage 3 genannten Dienstgrade sind in der durch die Dienstgradstufen der jeweiligen 
+      (3) 1Die in Anlage 3 genannten Dienstgrade sind in d er durch die Dienstgradstufen der jeweiligen 
       Dienstgradgruppe vorgegebenen Reihenfolge zu durchlaufen, bevor der Dienstgrad der nächsthöheren 
-      Dienstgradstufe der Dienstgradgruppe verliehen werden darf. 2Ist einem Mitglied die vorletzte Dienst-
+      Dienstgradstufe der Dienstgradgruppe verliehen werden darf.  2Ist einem Mitglied die vorletzte Dienst-
       gradstufe einer Dienstgradgruppe verliehen worden, so darf ihm der Dienstgrad der ersten Dienstgrad-
       stufe der nächsthöheren Dienstgradgruppe verliehen werden, wenn es die Voraussetzungen nach Ab-
-      satz 2 Satz 1 erfüllt.  
-      (4) 1Ist einem Mitglied der Freiwilligen Feuerwehr oder Pflichtfeuerwehr ein Dienstgrad verliehen 
-      worden, so darf nach Absatz 3 ein Dienstgrad der nächsthöheren Dienstgradstufe derselben Dienst-
+      satz 2 Satz 1 erfüllt.   
+      (4) 1Ist einem Mitglied der Freiwilligen Feuerwehr od er Pflichtfeuerwehr ein Dienstgrad verliehen 
+      worden, so darf nach Absatz  3 ein Dienstgrad der nächsthöheren Dienstgradstufe derselben Dienst-
       gradgruppe oder der ersten Dienstgradstufe der darauffolgenden Dienstgradgruppe erst nach Ablauf 
       eines Jahres seit der Verleihung verliehen werden. 2Erfolgt die Verleihung von Dienstgraden im Rahmen 
       einer jährlichen Dienstversammlung, so kann die Jahresfrist abweichend von Satz 1 um bis zu einen 
       Monat unterschritten werden.  
-      (5) Ein Doppelmitglied nach § 12 Abs. 2 Satz 2 NBrandSchG hat in der Freiwilligen Feuerwehr der 
+      (5) Ein Doppelmitglied nach §  12 Abs. 2 Satz 2 NBrandSchG hat in der Freiwilligen Feuerwehr der 
       anderen Gemeinde denselben Dienstgrad, den das Mitglied in der Gemeinde hat, in der es Vollmitglied 
       der Einsatzabteilung ist. 
       (6) Wechselt ein Mitglied einer Einsatzabteilung einer Freiwilligen Feuerwehr oder einer Pflichtfeu-
@@ -325,82 +325,82 @@ pages:
       (7) Ist einem Mitglied einer Freiwilligen Feuerwehr oder Pflichtfeuerwehr ein Dienstgrad einer Frei-
       willigen Feuerwehr oder Pflichtfeuerwehr eines anderen Bundeslandes oder einer Feuerwehr eines an-
       deren Landes verliehen worden und entsprechen die Voraussetzungen für die Verleihung dieses Dienst-
-      grades den Voraussetzungen für die Verleihung eines Dienstgrades nach der Anlage 3 Teil A Spalte 4, 
+      grades den Voraussetzungen für die Verleihung eines Dienstgrades nach der Anlage  3 Teil A Spalte 4, 
       so ist diesem Mitglied bei Eintritt in die Einsatzabteilung einer Freiwilligen Feuerwehr oder Pflichtfeuer-
-      wehr in Niedersachsen der Dienstgrad der höchsten Dienstgradstufe und Dienstgradgruppe der An-
+      wehr in Niedersachsen der Dienstgrad der höchsten Dienstgradstufe und Dienstgradgruppe  der An-
       lage 3 Teil A Spalte 2 zu verleihen, dessen Voraussetzungen für die Verleihung den Voraussetzungen 
       des bereits verliehenen Dienstgrades entsprechen. 
       (8) Mitglieder der Freiwilligen Feuerwehr oder Pflichtfeuerwehr, die aus einer Einsatzabteilung in 
-      eine Alters- oder Ehrenabteilung wechseln (§ 12 Abs. 2 Satz 4 NBrandSchG), dürfen ihre zuletzt ge-
-      führten Dienstgrade weiterführen. 
-      (9) 1Dienstgrade nach Anlage 3 werden von dem jeweiligen Träger der Feuerwehr verliehen. 2Ab-
+      eine Alters- oder Ehrenabteilung wechseln (§  12 Abs. 2 Satz 4 NBrandSchG), dürfen ihre zuletzt ge-
+      führten Dienstgrade weiterführen.  
+      (9) 1Dienstgrade nach Anlage  3 werden von dem jeweiligen Träger der Feuerwehr verliehen.  2Ab-
       weichend von Satz 1 werden 
-      1. Dienstgrade an Mitglieder, die in die Einsatzabteilung eintreten und zuletzt einen Dienstgrad einer 
+      1.  Dienstgrade an Mitglieder, die in die Einsatzabteilung eintreten und zuletzt einen Dienstgrad einer 
       ausländischen Feuerwehr geführt haben, im Einvernehmen mit dem für Inneres zuständigen Mi-
       nisterium und 
-      2. die Dienstgrade Regierungsbrandinspektorin und Regierungsbrandinspektor von dem für Inneres 
-      zuständigen Ministerium oder der von ihm bestimmten Landesbehörde  
-      verliehen. 
-      (10) 1Die für Inneres zuständige Ministerin oder der für Inneres zuständige Minister kann zusätzlich 
-      zu den Dienstgraden nach Absatz 1 den Sonderdienstgrad ,Landesbrandinspektorinʻ oder ,Landes-
-      brandinspektorʻ an ein Mitglied der Freiwilligen Feuerwehr oder Pflichtfeuerwehr verleihen, wenn sich 
-      das Mitglied besonders für den Brandschutz in Niedersachsen engagiert oder um den Brandschutz in 
+      2.  die Dienstgrade Regierungsbrandinspektorin und Regierungsbrandinspektor von dem für Inneres 
+      zuständigen Ministerium oder der von ihm bestimmten Landesbehörde   
+      verliehen.  
+      (10) 1Die fü r Inneres zuständige Ministerin oder der für Inneres zuständige Minister kann zusätzlich 
+      zu den Dienstgraden nach Absatz  1 den Sonderdienstgrad  ,Landesbrandinspektorinʻ oder ,Landes-
+      brandinspektorʻ an ein Mitglied der Freiwilligen Feuerwehr oder Pflichtfeuerwehr verleihen , wenn sich 
+      das Mitglied  besonders für den Brandschutz in Niedersachsen engagiert oder um den Brandschutz in 
       Niedersachsen verdient gemacht hat, insbesondere indem es zur Fortentwicklung des Brandschutzes 
       und der Hilfeleistung der Feuerwehren in Niedersachsen in herausragender Weise beigetragen hat. 
-      2Der Sonderdienstgrad wird mit der Abkürzung ,LBIinʻ oder ,LBIʻ geführt. 
-      (11) Dienstgrade begründen keine Weisungsbefugnisse. 
+      2Der Sonderdienstgrad wird mit der Abkürzung , LBIinʻ oder ,LBIʻ geführt.  
+      (11) Dienstgrade begründen keine Weisungsbefugnisse.  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 8 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 8 
        
       Dritter Teil 
-      Persönliche Ausrüstung, Dienstkleidung, Dienstgradabzeichen 
+      Persönliche Ausrüstung, Dienstkleidung, Dienstgradabzeichen  
       § 12 
-      Persönliche Ausrüstung und Dienstkleidung der Mitglieder 
+      Persönliche Ausrüstung und Dienstkleidung der Mitglieder  
       der Freiwilligen Feuerwehr oder Pflichtfeuerwehr 
       (1) 1Die Mitglieder der Einsatzabteilung der Freiwilligen Feuerwehr oder Pflichtfeuerwehr tragen im 
-      Einsatzdienst und, wenn dies erforderlich ist, auch im Übungsdienst die in Anlage 4 beschriebene per-
-      sönliche Ausrüstung. 2Bei der Ausübung dienstlicher Tätigkeit mit repräsentativem Anlass, insbeson-
+      Einsatzdienst und, wenn dies erforderlich ist, auch im Übungsdienst die in Anlage  4 beschriebene per-
+      sönliche Ausrüstung.  2Bei der Ausübung dienstlicher Tätigkeit mit repräsentativem Anlass, insbeson-
       dere bei den vom Träger der Feuerwehr festgelegten Veranstaltungen wie Jahreshauptversammlungen, 
       Gedenkveranstaltungen und Brauchtumsveranstaltungen, tragen die Mitglieder die in Anlage 5 Teile A 
       und C beschriebene Dienstkleidung. 3Die Mitglieder können nach Festlegung des Trägers der Feuer-
-      wehr bei der Ausübung sonstiger dienstlicher Tätigkeit die in Anlage 5 Teil D beschriebene Tagesdienst-
+      wehr bei der Ausübung sonstiger dienstlicher Tät igkeit die in Anlage  5 Teil D beschriebene Tagesdienst-
       kleidung oder die in Anlage 5 Teil E beschriebene Wetterschutzkleidung tragen. 
       (2) Die Mitglieder einer Musikabteilung, die nicht Mitglieder der Einsatzabteilung sind, tragen bei 
-      Ausübung dienstlicher Tätigkeit die in Anlage 5 Teile A und C beschriebene Dienstkleidung. 
+      Ausübung dienstlicher T ätigkeit die in Anlage  5 Teile A und C beschriebene Dienstkleidung. 
       (3) Die Mitglieder einer Alters- oder Ehrenabteilung der Freiwilligen Feuerwehr oder Pflichtfeuerwehr 
-      dürfen nach dem Wechsel in die Alters- oder Ehrenabteilung zur Ausübung dienstlicher Tätigkeit mit 
-      repräsentativem Anlass die in Anlage 5 Teile A und C beschriebene Dienstkleidung tragen.  
+      dürfen nach dem Wechsel in die Alters - oder Ehrenabteilung zur Ausübung dienstlicher T ätigkeit mit 
+      repräsentativem Anlass die in Anlage  5 Teile A und C beschriebene Dienstkleidung tragen.  
       (4) Die Mitglieder der Jugendfeuerwehr tragen bei Ausübung dienstlicher Tätigkeit die in Anlage 6 
       beschriebene Dienstkleidung. 
       § 13 
       Dienstgradabzeichen, Gestaltung und Kennzeichnung der persönlichen Ausrüstung 
       der Mitglieder der Freiwilligen Feuerwehr oder Pflichtfeuerwehr 
       (1) 1Die Mitglieder der Einsatzabteilung einer Freiwilligen Feuerwehr oder Pflichtfeuerwehr tragen 
-      auf der Dienstkleidung die in Anlage 7 beschriebenen und den Dienstgraden jeweils zugeordneten 
+      auf der Dienstkleidung die in Anlage  7 beschriebenen und den Dienstgraden jeweils zugeordneten 
       Dienstgradabzeichen. 2Die Kennzeichnung der von ihnen während des Einsatzdienstes getragenen 
       Feuerwehrhelme und die Zuordnung zu der zum Tragen erforderlichen Ausbildung richtet sich nach 
-      Anlage 8 Teil A. 3Für die Abschnittsleiterin, den Abschnittsleiter, die Kreisbrandmeisterin, den Kreis-
+      Anlage 8  Teil A. 3Für die Abschnittsleiterin, den Abschnittsleiter, die Kreisbrandmeisterin, den Kreis-
       brandmeister, die Regierungsbrandmeisterin und den Regierungsbrandmeister ergibt sich die Kenn-
-      zeichnung der während des Einsatzdienstes getragenen Feuerwehrhelme aus Anlage 8 Teil B. 4Die 
+      zeichnung der während des Einsatzdienstes getragenen Feuerwehrhelme aus Anlage  8 Teil B. 4Die 
       Gestaltung und Kennzeichnung der Funktionswesten und Funktionskoller und die Zuordnung zu der 
       von den Mitgliedern der Einsatzabteilung wahrgenommenen einsatzspezifischen Funktion richtet sich 
       nach Anlage 8 Teil C.  
-      (2) Die Mitglieder einer Alters- oder Ehrenabteilung der Freiwilligen Feuerwehr oder Pflichtfeuerwehr 
-      tragen bei Ausübung dienstlicher Tätigkeit mit repräsentativem Anlass die in Anlage 7 beschriebenen 
-      und den Dienstgraden jeweils zugeordneten Dienstgradabzeichen. 
+      (2) Die Mitglieder einer Alters- oder Ehrenabteilung  der Freiwilligen Feuerwehr oder Pflichtfeuerwehr 
+      tragen bei Ausübung dienstlicher Tätigkeit mit repräsentativem Anlass die in Anlage  7 beschriebenen 
+      und den Dienstgraden jeweils zugeordneten Dienstgradabzeichen.  
       § 14 
       Dienstgradabzeichen und Kennzeichnung der Feuerwehrhelme  
-      für Beamtinnen und Beamte des Feuerwehrdienstes 
+      für Beamtinnen und Beamte des Feuerwehrdienstes  
       1Beamtinnen und Beamte des Feuerwehrdienstes tragen auf der Dienstkleidung das ihrer Amtsbe-
-      zeichnung und dem jeweiligen Zusatz in Anlage 9 jeweils zugeordnete Dienstgradabzeichen.  2Beam-
+      zeichnung und dem jeweiligen Zusatz in A nlage 9  jeweils zugeordnete Dienstgradabzeichen.  2Beam-
       tinnen oder Beamte des Feuerwehrdienstes, die auch Mitglied der Einsatzabteilung einer Freiwilligen 
       Feuerwehr oder Pflichtfeuerwehr sind, tragen während des Einsatzdienstes in der Freiwilligen Feuer-
-      wehr oder Pflichtfeuerwehr die nach Anlage 10 gekennzeichneten und der jeweiligen Ausbildung der 
+      wehr oder Pflichtfeuerwehr die nach  Anlage 10  gekennzeichneten und der jeweiligen Ausbildung der 
       Beamtinnen und Beamten zugeordneten Feuerwehrhelme.  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 9 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 9 
        
       § 15  
       Tragen von Wappen auf der Dienstkleidung 
@@ -408,146 +408,146 @@ pages:
       rinnen und Regierungsbrandmeister tragen auf der Dienstkleidung das Landeswappen, wenn in An-
       lage 5 Teile C bis E das Tragen von Wappen vorgesehen ist.  
       (2) 1Mitglieder der Freiwilligen Feuerwehr oder Pflichtfeuerwehr tragen auf der Dienstkleidung den in 
-      Anlage 5 Teil B dargestellten Schriftzug ,Feuerwehrʻ mit dem Landeswappen, wenn in Anlage 5 Teile C 
-      bis E das Tragen des Schriftzuges vorgesehen ist. 2Sie dürfen nach Festlegung des Trägers der Feu-
-      erwehr das Gemeinde- oder Landkreiswappen tragen, wenn in Anlage 5 Teile C bis E das Tragen von 
+      Anlage  5 Teil B dargestellten Schriftzug , Feuerwehrʻ mit dem Landeswappen, wenn in Anlage 5 Teile  C 
+      bis E das Tragen des Schriftzuges vorgesehen ist.  2Sie dürfen nach Festlegu ng des Trägers der Feu-
+      erwehr das Gemeinde-  oder Landkreiswappen tragen, wenn in Anlage  5 Teile C bis E das Tragen von 
       Wappen auf der Dienstkleidung vorgesehen ist. 
       § 16 
       Vereinbarungen mit dem Landesfeuerwehrverband Niedersachsen e.V. 
-      Das für Inneres zuständige Ministerium kann mit dem Landesfeuerwehrverband Niedersachsen e.V. 
+      Das für Inneres zuständige Ministerium kann mit dem Landesfeuerwehrverband Niedersachsen  e.V. 
       eine Vereinbarung treffen über das Tragen von Dienstkleidung und Abzeichen durch Mitglieder des 
       Landesfeuerwehrverbandes Niedersachsen e.V. 
-      10. § 17 erhält folgende Fassung: 
+      10.   § 17 erhält  folgende Fassung: 
       § 17 
-      Übergangsvorschriften 
+      Übergangsvorschriften  
       (1) Am 30. April 2010 vorhandene Feuerwehrfahrzeuge, die den Vorgaben der bis zum 6. Mai 2010 
       geltenden Verordnung über die Mindeststärke, die Gliederung nach Funktionen und die Mindestausrüs-
-      tung der Freiwilligen Feuerwehren im Lande Niedersachsen vom 21. September 1993 (Nds. GVBl. 
-      S. 365, 570), zuletzt geändert durch Artikel 2 der Verordnung vom 8. August 2005 (Nds. GVBl. S. 266), 
+      tung der Freiwilligen Feuerwehren im Lande Nie dersachsen vom 21.  September 1993 (Nds. GVBl. 
+      S. 365, 570), zuletzt geändert durch Artikel  2 der Verordnung vom 8. August 2005 (Nds. GVBl. S. 266), 
       entsprechen, werden bis zum Zeitpunkt ihrer Aussonderung der nach § 4 vorgeschriebenen Min-
-      destausrüstung gleichgesetzt. 
-      (2) Dienstkleidung, die bis zum 10. April 2025 getragen werden durfte (alte Dienstkleidung), darf bis 
+      destausrüstung gle ichgesetzt. 
+      (2) Dienstkleidung, die bis zum  10. April 2025 getragen werden durfte (alte Dienstkleidung), darf bis 
       zu dem Zeitpunkt weitergetragen werden, für den der Träger der Freiwilligen Feuerwehr oder Pflichtfeu-
-      erwehr festgelegt hat, dass zu einer Dienstkleidung gewechselt wird, die die Anforderungen der An-
-      lage 5 erfüllt (neue Dienstkleidung).  
-      (3) Dienstgradabzeichen, die bis zum 10. April 2025 getragen werden durften, dürfen auf der alten 
+      erwehr festgelegt hat, dass zu einer  Dienstkleidung gewechselt wird, die die Anforderungen der An-
+      lage 5 erfüllt (neue Dienstkleidung).   
+      (3) Dienstgradabzeichen, die bis zum 10. April 2025  getragen werden durften, dürfen auf der alten 
       Dienstkleidung weitergetragen werden. 
       (4) Hat der Träger der Freiwilligen Feuerwehr oder der Pflichtfeuerwehr festgelegt, zu einer neuen 
       Dienstkleidung zu wechseln, so sind Dienstgrade nach Anlage 3 Teile A und B jeweils Spalte 2 (neue 
       Dienstgrade) zu verleihen und Dienstgradabzeichen nach Anlage 7 (neue Dienstgradabzeichen) zu tra-
       gen.  
       (5) 1Im Falle einer Festlegung nach Absatz 4  
-      1. wird einem Mitglied der neue Dienstgrad verliehen, der dem von ihm zuletzt geführten, in Anlage 
+      1.  wird einem Mitglied der neue Dienstgrad verliehen, der dem von ihm zuletzt geführten, in Anlage 
       3 Teile A und B jeweils Spalte 5 genannten Dienstgrade (alter Dienstgrad) zugeordnet ist und 
-      2. trägt das Mitglied das neue Dienstgradabzeichen, das nach Anlage 7 Spalte 2 dem neuen 
+      2.  trägt das Mitglied das neue Dienstgradabzeichen, das nach Anlage 7 Spalte 2 dem neuen 
       Dienstgrad zugeordnet ist. 
       2Erfüllt das Mitglied zum Zeitpunkt des Wechsels der Dienstkleidung die Voraussetzungen nach An-
-      lage 3 Teile A und B jeweils Spalte 4 für die Verleihung eines höheren neuen Dienstgrades derselben 
+      lage 3 Teile A und B jeweils Spalte 4 f ür die Verleihung eines höheren neuen Dienstgrades derselben 
       Dienstgradstufe, so wird ihm der Dienstgrad verliehen, der dem höheren neuen Dienstgrad zugeordnet 
       ist. 3Erfüllt das Mitglied die Voraussetzungen des ersten Dienstgrades der nächsthöheren Dienstgrad-
       stufe, so wird ihm dieser verliehen.  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 10 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 10 
        
-      (6) Der Träger der Freiwilligen Feuerwehr oder Pflichtfeuerwehr legt fest, ob mit alter Dienstkleidung  
-      1. die alten Dienstgrade geführt und verliehen werden sowie die Dienstgradabzeichen nach An-
-      lage 6 dieser Verordnung in der am 10. April 2025 geltenden Fassung (alte Dienstgradabzeichen) 
+      (6) Der Träger der Freiwilligen Feuerwehr oder Pflichtfeuerwehr legt fest, ob mit alter Dienstkleidung   
+      1.  die alten Dienstgrade geführt und verliehen werden sowie die Dienstgradabzeichen nach An-
+      lage 6 dieser Verordnung in der am  10. April 2025 geltenden Fassung (alte Dienstgradabzeichen) 
       getragen werden oder 
-      2. die neuen Dienstgrade verliehen und geführt werden sowie die neuen Dienstgradabzeichen ge-
+      2.  die neuen Dienstgrade verliehen und geführt werden sowie die neuen Dienstgradabzeichen ge-
       tragen werden. 
-      (7) Im Fall einer Festlegung nach Absatz 6 Nr. 1 werden  
-      1. die alten Dienstgrade unter den Voraussetzungen der Anlage 3 Teile A und B jeweils Spalte 4 
+      (7) Im Fall einer Festlegung nach Absatz 6 Nr. 1 werden   
+      1.  die alten Dienstgrade unter den Voraussetzungen der Anlage 3 Teile A und B jeweils Spalte  4 
       verliehen und  
-      2. die den alten Dienstgraden nach Anlage 6 dieser Verordnung in der am 10. April 2025 geltenden 
-      Fassung zugeordneten alten Dienstgradabzeichen getragen. 
+      2.  die den alten Dienstgraden nach Anlage 6 dieser Verordnung in der am 10. April 2025  geltenden 
+      Fassung zugeordneten alten Dienstgradabzeichen  getragen. 
       (8) 1Im Fall einer Festlegung nach Absatz 6 Nr. 2  
-      1. wird einem Mitglied der neue Dienstgrad verliehen, der dem von ihm zuletzt geführten alten 
-      Dienstgrad nach Anlage 3 Teile A und B jeweils Spalte 5 zugeordnet ist, und  
-      2. trägt das Mitglied das neue Dienstgradabzeichen, das nach Anlage 7 Spalte 2 dem neuen Dienst-
+      1.  wird einem Mitglied der neue Dienstgrad verliehen, der dem von ihm zuletzt geführten alten 
+      Dienstgrad nach Anlage 3  Teile A und B jeweils Spalte 5 zugeordnet ist, und  
+      2.  trägt das Mitglied das neue Dienstgradabzeichen, das nach Anlage 7 Spalte 2 dem neuen Dienst-
       grad zugeordnet ist.  
-      2Erfüllt das Mitglied zum Zeitpunkt der Festlegung nach Satz 1 die Voraussetzungen nach Anlage 3 
+      2Erfüllt das Mitglied zum Zeitpunkt der Festlegung nach Satz 1 die Voraussetzungen nach Anlage  3 
       Teile A und B jeweils Spalte 4 für die Verleihung eines höheren neuen Dienstgrades derselben Dienst-
       gradstufe, so wird ihm der Dienstgrad verliehen, der dem höheren neuen Dienstgrad zugeordnet ist. 
       3Erfüllt das Mitglied die Voraussetzungen des ersten Dienstgrades der nächsthöheren Dienstgradstufe, 
       so wird ihm dieser verliehen.  
       (9) 1Alte Dienstgrade, die nach der Anlage 3 Teile A und B jeweils Spalte 2 nicht mehr vorgesehen 
-      sind, werden bis zum Zeitpunkt des Wechsels der Dienstgradabzeichen weitergeführt.  
+      sind, werden bis zum Zeitpunkt des Wechsels der Dienstgradabzeichen weitergeführt.   
       (10) 1Abweichend von § 11 Abs. 2 Nr. 1 wird einem Mitglied der Freiwilligen Feuerwehr oder Pflicht-
       feuerwehr, das nicht über eine abgeschlossene modulare Grundlagenausbildung zur Truppführerin oder 
       zum Truppführer verfügt, der Dienstgrad Hauptfeuerwehrfrau oder Hauptfeuerwehrmann auch verlie-
       hen, wenn es über eine Mindestdienstzeit von zehn Jahren seit dem Zeitpunkt der Verleihung des 
       Dienstgrades Feuerwehrfrauanwärterin oder Feuerwehrmannanwärter verfügt und es  
-      1. vor dem 1. Januar 2024 die ,Truppmannausbildung Teil 2ʻ nach dem bis zum 18. Juli 2016 gel-
-      tenden Runderlass ,Ausbildung der Freiwilligen Feuerwehren; Feuerwehr-Dienstvorschrift 2 
-      (FwDV 2)ʻ des Ministeriums für Inneres und Sport vom 10. September 2012 (Nds. MBl. S. 764) 
+      1.  vor dem 1. Januar 2024 die ,Truppmannausbildung Teil 2ʻ nach dem bis zum 18. Juli 2016 gel-
+      tenden Runderlass ,Ausbildung der Freiwilligen Feuerwehren;  Feuerwehr-Dienstvorschrift 2 
+      (FwDV 2)ʻ des Ministeriums für Inneres und Sport vom 10. September 2012 (Nds. MBl.  S. 764) 
       (erster Erlass-FwDV 2) und  
-      2. zwei weitere technische Ausbildungslehrgänge (Atemschutzgeräteträger, Sprechfunker, Maschi-
+      2.  zwei weitere technische Ausbildungslehrgänge (Atemschutzgeräteträger, Sprechfunker, Maschi-
       nisten, Technische Hilfeleistung oder ABC-Einsatz) nach dem ersten Erlass-FwDV 2  
       abgeschlossen hat. 2Mitgliedern, denen nach Satz 1 der Dienstgrad Hauptfeuerwehrfrau oder Haupt-
       feuerwehrmann verliehen werden kann, darf nach einer Mindestdienstzeit von zwanzig Jahren seit dem 
-      Zeitpunkt der Verleihung des Dienstgrades Feuerwehrfrauanwärterin oder Feuerwehrmannanwärter der 
+      Zeitpunkt der Verleihung des Dienstgrades Feuerwehrfrauanwärterin oder Feuerwehrmannanwärter  der 
       Dienstgrad Erste Hauptfeuerwehrfrau oder Erster Hauptfeuerwehrmann verliehen werden. 
-      (11) Abweichend von § 13 Abs. 1 Satz 2 tragen Mitglieder der Einsatzabteilung, die bis zum 10. April 
+      (11) Abweichend von §  13 Abs. 1 Satz 2 tragen Mitglieder der Einsatzabteilung, die bis zum 10. April 
       2025 zu Ortsbrandmeisterinnen und Ortsbrandmeistern einer Grundausstattungsfeuerwehr ernannt 
-      wurden und den Ausbildungslehrgang ,Gruppenführerʻ abgeschlossen haben, als Kennzeichnung auf 
+      wurden und den Ausbildungslehrgang  ,Gruppenführerʻ abgeschlossen haben, als Kennzeichnung auf 
       dem Feuerwehrhelm zwei rote Streifen auf beiden Helmseiten in der aus der Anlage 8 Teil A ersichtli-
-      chen Ausführung. 
+      chen Ausführung.  
       (12) Bis zum Eintritt in den Ruhestand tragen Beamtinnen und Beamte des Feuerwehrdienstes, die 
       aufgrund laufbahnrechtlicher Vorschriften eine Amtsbezeichnung mit Zusatz führen, die nicht mehr ver-
-      geben wird, das Dienstgradabzeichen, das nach Anlage 9 Teil B der Amtsbezeichnung mit Zusatz zu-
+      geben wird, das Dienstgradabzeichen, das nach Anlage  9 Teil B der Amtsbezeichnung mit Zusatz zu-
       geordnet ist. 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 11 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 11 
        
-      11. In der Bezeichnung der Anlage 1 erhält der Klammerzusatz folgende Fassung:  
+      11.   In der Bezeichnung der Anlage  1 erhält der Klammerzusatz folgende Fassung:   
       (zu § 4). 
-      12. Anlage 2 erhält folgende Fassung: 
+      12.   Anlage  2 erhält folgende Fassung:  
       Anlage 2  
       (zu § 10 Abs. 1 und 4) 
-      Voraussetzungen für die Übertragung von Funktionen 
+      Voraussetzungen für die Übertragung von Funktionen  
       Teil A 
       Regelfunktionen für Mitglieder der Freiwilligen Feuerwehr oder Pflichtfeuerwehr  
-      mit Ausnahme der ehrenamtlichen Führungskräfte 
+      mit Ausnahme der ehrenamtlichen Führungskräfte  
       Bezeichnung der Re-
-      Voraussetzung für die Übertragung der Regelfunktion 
+      Voraussetzung für die Übertragung der Regelfunktion  
       gelfunktion 
       Abschluss 
       der modula-
-      Abschluss Abschluss 
-      ren Grundla-Abschluss 
-      des Ausbil-des Ausbil-
-      genausbil-des Ausbil-Weitere Ausbildungs-
-      dungslehr-dungslehr-
-       dung zur dungslehr-lehrgänge, die abzu-
-      gangs gangs ,Ver-
-      Trupp- gangs schließen sind 
-      ,Gruppen-bandsfüh-
+      Abschluss  Abschluss 
+      ren Grundla- Abschluss 
+      des Ausbil- des Ausbil-
+      genausbil- des Ausbil- Weitere Ausbildungs-
+      dungslehr- dungslehr-
+        dung zur  dungslehr- lehrgänge, die abzu-
+      gangs  gangs ,Ver-
+      Trupp-   gangs  schließen sind  
+      ,Gruppen- bandsfüh-
       führerin oder ,Zugführerʻ 
-      führerʻ rerʻ 
+      führerʻ  rerʻ  
       zum Trupp-
-      führer 
+      führer  
       Truppführerin oder 
-      Truppführer eines X X    
-      selbständigen Trupps 
+      Truppführer eines  X  X       
+      selbständigen Trupps  
       Staffelführerin oder 
-      X X    
-      Staffelführer 
-      Gruppenführerin oder  
-      X X    
-      Gruppenführer 
+      X  X       
+      Staffelführer  
+      Gruppenführerin oder   
+      X  X       
+      Gruppenführer  
       Zugführerin oder 
-      X X X   
-      Zugführer 
+      X  X  X     
+      Zugführer  
       Verbandsführerin 
-      oder  X X X X  
-      Verbandsführer 
+      oder   X  X  X  X   
+      Verbandsführer  
       Sicherheitsbeauf-
       tragte oder Sicher-
       heitsbeauftragter und 
       Stellvertretende Si-
-      X     
+      X         
       cherheitsbeauftragte 
       oder  
       Stellvertretender Si-
@@ -557,41 +557,41 @@ pages:
       Gerätewart und Stell-
       Ausbildungslehr-
       vertretende Geräte-
-      X    gänge  
+      X        gänge   
       wartin oder  
-      ,Maschinistenʻ und 
+      ,Maschinistenʻ  und 
       Stellvertretender  
-      ,Gerätewarteʻ 
-      Gerätewart 
+      ,Gerätewarteʻ  
+      Gerätewart  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 12 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 12 
        
       Atemschutzgeräte-
-      wartin oder Atem-Abschluss der  
-      schutzgerätewart und Ausbildungslehr-
-      Stellvertretende gänge ,Atemschutz-
-      X    
-      Atemschutzgeräte-geräteträgerʻ und 
-      wartin oder Stellver-,Atemschutzgeräte-
-      tretender Atem-warteʻ 
-      schutzgerätewart 
-      Atemschutzbeauf-X X   Abschluss der  
-      tragte  Ausbildungslehr-
-      oder  gänge ,Atemschutz-
-      Atemschutzbeauf-geräteträgerʻ und 
-      tragter ,Atemschutzbeauf-
+      wartin oder Atem- Abschluss der  
+      schutzgerätewart und  Ausbildungslehr-
+      Stellvertretende  gänge  ,Atemschutz-
+      X       
+      Atemschutzgeräte- geräteträgerʻ und 
+      wartin oder Stellver- ,Atemschutzgeräte-
+      tretender Atem- warteʻ  
+      schutzgerätewart  
+      Atemschutzbeauf- X  X      Abschluss der  
+      tragte   Ausbildungslehr-
+      oder   gänge  ,Atemschutz-
+      Atemschutzbeauf- geräteträgerʻ und 
+      tragter  ,Atemschutzbeauf-
       tragteʻ 
       Abschluss der  
-      Gerätebeauftragte Ausbildungslehr-
-      oder  X X   gänge  
-      Gerätebeauftragter ,Maschinistenʻ und 
-      ,Gerätebeauftragteʻ  
+      Gerätebeauftragte  Ausbildungslehr-
+      oder   X  X      gänge   
+      Gerätebeauftragter   ,Maschinistenʻ  und 
+      ,Gerätebeauftragteʻ   
       Jugendfeuerwehr-
       wartin oder Jugend-
       feuerwehrwart und 
       Stellvertretende  
-      X X    
+      X  X       
       Jugendfeuerwehr-
       wartin oder Stellver-
       tretender Jugendfeu-
@@ -599,33 +599,33 @@ pages:
       Pressesprecherin 
       oder Pressesprecher 
       und Stellvertretende 
-      X X    
+      X  X       
       Pressesprecherin 
       oder Stellvertreten-
       der Pressesprecher 
       Ausbilderin oder Aus-
-      bilder in der Feuer-Abschluss des Aus-
-      wehr sowie Ausbil-bildungslehrgangs 
-      dungsleitung und ,Ausbilder in der  
-      Stellvertretende Aus-Feuerwehrʻ und Ab-
-      bilderin oder Stellver-schluss des Ausbil-
-      tretender Ausbilder in dungslehrgangs der 
-      der Feuerwehr sowie X X   jeweiligen Fachrich-
-      Stellvertretende Aus-tung in der Ausbil-
-      bildungsleiterin oder dung, insbesondere 
-      Stellvertretender ,Maschinistenʻ, 
-      Ausbildungsleiter ,Atemschutzgeräte-
-      (auf Ebene einer Ge-warteʻ oder ,Sprech-
-      meinde oder eines funkerʻ 
+      bilder in der Feuer- Abschluss des Aus-
+      wehr sowie Ausbil- bildungslehrgangs 
+      dungsleitung und  ,Ausbilder in der  
+      Stellvertretende Aus- Feuerwehrʻ und Ab-
+      bilderin oder Stellver- schluss des Ausbil-
+      tretender Ausbilder in  dungslehrgangs der 
+      der Feuerwehr sowie  X  X      jeweiligen  Fachrich-
+      Stellvertretende Aus- tung in der Ausbil-
+      bildungsleiterin oder  dung, insbesondere 
+      Stellvertretender  ,Maschinistenʻ , 
+      Ausbildungsleiter  ,Atemschutzgeräte-
+      (auf Ebene einer Ge- warteʻ  oder ,Sprech-
+      meinde oder eines  funkerʻ 
       Landkreises) 
-        
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 13 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 13 
        
       Schriftführerin oder 
        
-      Schriftführer 
+      Schriftführer  
       Kinderfeuerwehrwar-
       tin oder Kinderfeuer-
       wehrwart und Stell-
@@ -636,115 +636,115 @@ pages:
       Kinder- 
       feuerwehrwart 
       Teil B 
-      Regelfunktionen für ehrenamtliche Führungskräfte nach den §§ 20 bis 22 NBrandSchG 
+      Regelfunktionen für ehrenamtliche Führungskräfte nach den  §§ 20 bis 22 NBrandSchG 
       Bezeichnung der  
-      Voraussetzung für die Übertragung der Regelfunktion 
+      Voraussetzung für die Übertragung der Regelfunktion  
       Regelfunktion 
-       Abschluss 
-      der modula-Abschluss 
-      Abschluss Abschluss Abschluss Abschluss 
-      ren Grund-des Ausbil-
-      des Ausbil-des  des Ausbil-des Ausbil-
-      lagenaus-dungslehr-
-      dungs- Ausbil-dungslehr-dungslehr-
-      bildung zur gangs ,Ein-
-      lehrgangs dungs- gangs  gangs  
-      Truppführe-führung in 
-      ,Gruppen-lehrgangs  ,Leiter einer  ,Verbands- 
-      rin oder die Stabs-
-      führerʻ  ,Zugführerʻ  Feuerwehrʻ  führerʻ  
-      zum Trupp-arbeitʼ  
-      führer 
+        Abschluss 
+      der modula- Abschluss 
+      Abschluss  Abschluss  Abschluss  Abschluss 
+      ren Grund- des Ausbil-
+      des Ausbil- des   des Ausbil- des Ausbil-
+      lagenaus- dungslehr-
+      dungs-  Ausbil- dungslehr- dungslehr-
+      bildung zur  gangs ,Ein-
+      lehrgangs  dungs-  gangs   gangs  
+      Truppführe- führung in 
+      ,Gruppen- lehrgangs   ,Leiter einer   ,Verbands- 
+      rin oder  die Stabs-
+      führerʻ   ,Zugführerʻ   Feuerwehrʻ   führerʻ  
+      zum Trupp- arbeitʼ  
+      führer  
       Stellvertretende 
       Ortsbrandmeisterin 
-      oder Stellvertreten-X X     
+      oder Stellvertreten- X  X         
       der Ortsbrandmeis-
       ter 
       Ortsbrandmeisterin 
-      oder Ortsbrand-X X X1) X   
+      oder Ortsbrand- X  X  X1)  X     
       meister 
       Stellvertretende 
-      Gemeinde- oder 
+      Gemeinde-  oder 
       Stadtbrandmeiste-
-      rin oder Stellvertre-X X X X   
-      tender Gemeinde- 
+      rin oder Stellvertre- X  X  X  X     
+      tender Gemeinde-  
       oder Stadtbrand-
       meister 
       Gemeinde- oder 
       Stadtbrandmeiste-
-      rin oder Gemeinde- X X X X X  
+      rin oder Gemeinde-   X  X  X  X  X   
       oder Stadtbrand-
       meister 
        
-      1) Abschluss des Ausbildungslehrgangs nicht erforderlich, wenn die Regelfunktion in einer Grundausstattungsfeu-
+      1)  Abschluss des Ausbildungslehrgangs nicht erforderlich, wenn die Regelfunktion in einer Grundausstattungsfeu-
       erwehr nach § 1 Abs. 1 Nr. 1 übertragen wird. 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 14 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 14 
        
-      Abschnittsleiterin     
+      Abschnittsleiterin         
        
       oder Abschnittslei-
-          
+             
        
       ter und Stellvertre-
-      X2) X X X 
-      tende Abschnittslei-X 
+      X2)  X  X  X 
+      tende Abschnittslei- X 
       terin oder Stellver-
-          
+             
        
       tretender Ab-
-          
+             
        
       schnittsleiter 
-          
+             
        
       oder 
-          
+             
        
       Stellvertretende 
       Stadtbrandmeiste-
-          
+             
        
       rin oder Stellvertre-
-      X2) X X X 
+      X2)  X  X  X 
       X 
       tender Stadtbrand-
       meister in Städten 
-          
+             
        
       mit Berufsfeuer-
-          
+             
        
       wehr 
        
-          
+             
        
       oder 
-          
+             
        
       Stellvertretende 
       Stadtbrandmeiste-
-          
+             
        
       rin oder Stellvertre-
-      X2) X X X 
+      X2)  X  X  X 
       X 
       tender Stadtbrand-
-      meister in kreis-    
+      meister in kreis-        
        
       freien Städten ohne 
-          
+             
        
       Berufsfeuerwehr 
-          
+             
        
       oder 
-          
+             
        
       Stadtbrandmeiste-
-      X2) X X X 
-      rin oder Stadt-X 
+      X2)  X  X  X 
+      rin oder Stadt- X 
       brandmeister in 
        
       Städten mit Berufs-
@@ -753,476 +753,476 @@ pages:
       Kreisbrandmeiste-
       rin oder Kreis-
       brandmeister und 
-      Stellvertretende X X2) X X X X 
+      Stellvertretende  X  X2)  X  X  X  X 
       Kreisbrandmeiste-
-            
+                 
       rin oder Stellvertre-
-      tender Kreisbrand-      
+      tender Kreisbrand-            
       meister 
-            
+                 
       oder 
-            
+                 
       Stadtbrandmeiste-
-            
+                 
       rin oder Stadt-
-      X X2) X X X X 
+      X  X2)  X  X  X  X 
       brandmeister in 
       kreisfreien Städten 
       ohne Berufsfeuer-
       wehr 
        
-      2) Sonstige Voraussetzungen: Zweijährige Mindestdienstzeit in einer Regelfunktion als Stellvertretende Orts-
+      2)  Sonstige Voraussetzungen: Zweijährige Mindestdienstzeit in einer Regelfunktion als Stellvertretende Orts-
       brandmeisterin oder Stellvertretender Ortsbrandmeister, Ortsbrandmeisterin oder Ortsbrandmeister, Stellver-
-      tretende Gemeinde- oder Stadtbrandmeisterin oder Stellvertretender Gemeinde- oder Stadtbrandmeister, Ge-
-      meinde- oder Stadtbrandmeisterin oder Gemeinde- oder Stadtbrandmeister sowie eine Gesamtdienstzeit von 
+      tretende Gemeinde-  oder Stadtbrandmeisterin oder Stellvertretender Gemeinde-  oder Stadtbrandmeister, Ge-
+      meinde-  oder Stadtbrandmeisterin oder Gemeinde-  oder Stadtbrandmeister sowie eine Gesamtdienstzeit von 
       mindestens zehn Jahren ab dem Datum der erstmaligen Verleihung eines Dienstgrades. 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 15 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 15 
        
       Regierungsbrand-
       meisterin oder Re-
-      X X2) X X X X 
+      X  X2)  X  X  X  X 
       gierungsbrand-
       meister 
       Teil C  
       Einsatzspezifische Funktionen nach § 10 Abs. 4 
       Bezeichnung der ein-
-      satzspezifischen Voraussetzung für die Übertragung der einsatzspezifischen Funktion 
+      satzspezifischen  Voraussetzung für die Übertragung der einsatzspezifischen Funktion  
       Funktion 
-       Abschluss der 
+        Abschluss der 
       Abschluss der 
-      modularen Abschluss des Abschluss des 
-      modularen Abschluss des 
-      Grundlagen-Ausbildungs-Ausbildungs-
-      Grundlagen-Ausbildungs-
-      ausbildung zur lehrgangs lehrgangs 
-      ausbildung lehrgangs 
-      Truppführerin ,Gruppen- ,Verbands- 
-      zum  ,Zugführerʻ 
-      oder zum führerʻ führerʻ 
+      modularen  Abschluss des  Abschluss des 
+      modularen  Abschluss des 
+      Grundlagen- Ausbildungs- Ausbildungs-
+      Grundlagen- Ausbildungs-
+      ausbildung zur  lehrgangs  lehrgangs 
+      ausbildung  lehrgangs 
+      Truppführerin  ,Gruppen-   ,Verbands- 
+      zum   ,Zugführerʻ 
+      oder zum  führerʻ  führerʻ 
       Truppmitglied 
-      Truppführer 
-      Truppführerin   
+      Truppführer  
+      Truppführerin     
       oder Truppführer 
-      eines  X X X  
+      eines   X  X  X   
       selbständigen 
       Trupps 
        
       Maschinistin  
-      X    
+      X       
       oder Maschinist 
        
-      Staffelführerin  
-      X X X  
-      oder Staffelführer 
-      Truppführerin   
+      Staffelführerin   
+      X  X  X   
+      oder Staffelführer  
+      Truppführerin     
       oder Truppführer 
       in einer Staffel 
-      oder einer Gruppe X X   
+      oder einer Gruppe  X  X     
       (auch als Teilein-
       heiten eines  
       Zuges)  
        
-      Gruppenführerin  
-      oder  X X X  
-      Gruppenführer 
+      Gruppenführerin   
+      oder   X  X  X   
+      Gruppenführer  
        
       Melderin oder  
-      X X   
+      X  X     
       Melder 
        
-      Zugführerin  
-      X X X X 
-      oder Zugführer 
+      Zugführerin   
+      X  X  X  X 
+      oder Zugführer  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 16 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 16 
        
-      Führungsassisten- 
+      Führungsassisten-  
       tin  
-      X X X  
+      X  X  X   
       oder Führungsas-
       sistent 
        
       Einsatzleiterin  
-      X X X  
+      X  X  X   
       oder Einsatzleiter 
-      Einsatzabschnitts- 
+      Einsatzabschnitts-  
       leiterin oder  
-      X X X  
+      X  X  X   
       Einsatzabschnitts-
       leiter 
-      Verbandsführerin  
-      oder  X X X X X 
-      Verbandsführer 
-      Weitere einsatz- 
+      Verbandsführerin   
+      oder   X  X  X  X  X 
+      Verbandsführer  
+      Weitere einsatz-  
       spezifische Funk-
-      tion nach § 2 
-      X.    
+      tion nach §  2 
+      X.       
       Abs. 2 Satz 1 in  
       einer taktischen 
       Einheit  
-      13. Es wird die folgende neue Anlage 3 eingefügt: 
+      13.   Es wird die folgende neue Anlage 3 eingefügt : 
       Anlage 3 
       (zu § 11) 
       Regelungen zu Dienstgraden 
-      Teil A: Verleihung von Dienstgraden nach Ausbildung und Mindestdienstzeit 
-      I. Erste Dienstgradgruppe ,Feuerwehrfrau oder Feuerwehrmannʻ 
-      Dienst-Alter Dienstgrad 
+      Teil A: Verleihung von Dienstgraden nach Ausbildung und Mindestdienstzeit  
+      I. Erste Dienstgradgruppe , Feuerwehrfrau oder Feuerwehrmannʻ 
+      Dienst- Alter Dienstgrad 
       Abkür-
-      grad-Dienstgrad Voraussetzungen für die Verleihung nach früherem 
+      grad- Dienstgrad  Voraussetzungen für die Verleihung   nach früherem 
       zung 
-      stufe Recht 
-      1 2 3 4 5 
-      1. Feuer-FF-A Eintritt in die Einsatzabteilung und Beginn oder Feuerwehr-
-      wehrfrau- oder alsbaldiger Beginn der modularen Grundlagen-frauanwärterin  
-      anwärterin  FM-A ausbildung zur Einsatzfähigkeit  oder  
-      oder  Feuerwehr- 
-      Feuer-mannanwärter 
+      stufe  Recht 
+      1  2  3  4  5 
+      1.  Feuer- FF-A  Eintritt in die Einsatzabteilung und Beginn oder  Feuerwehr-
+      wehrfrau-   oder  alsbaldiger Beginn der modularen Grundlagen- frauanwärterin   
+      anwärterin    FM-A  ausbildung zur Einsatzfähigkeit    oder  
+      oder   Feuerwehr- 
+      Feuer- mannanwärter  
       wehr-
-      mann- 
-      anwärter 
-      2. Feuer-FF oder Abschluss der modularen Grundlagenausbil-Feuerwehrfrau  
-      wehrfrau FM dung zur Einsatzfähigkeit oder  
-      oder  Feuerwehr-
-      Feuer-mann 
+      mann-  
+      anwärter  
+      2.  Feuer- FF oder  Abschluss der modularen Grundlagenausbil- Feuerwehrfrau  
+      wehrfrau  FM  dung zur Einsatzfähigkeit   oder  
+      oder   Feuerwehr-
+      Feuer- mann 
       wehrmann 
-        
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 17 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 17 
        
-      3. Oberfeuer-OFF oder Abschluss der modularen Grundlagenaus-Oberfeuerwehr-
-      wehrfrau  OFM bildung zum Truppmitglied frau oder  
-      oder  Oberfeuerwehr-
-      Oberfeuer-mann 
+      3.  Oberfeuer- OFF oder  Abschluss der modularen Grundlagenaus- Oberfeuerwehr-
+      wehrfrau   OFM  bildung zum Truppmitglied  frau oder  
+      oder   Oberfeuerwehr-
+      Oberfeuer- mann 
       wehrmann 
-      4. Hauptfeuer-HFF oder Abschluss der modularen Grundlagenaus-Hauptfeuer-
-      wehrfrau  HFM bildung zur Truppführerin oder zum Trupp-wehrfrau oder  
-      oder  führer und einer dreijährigen Mindestdienst-Hauptfeuer-
-      Hauptfeuer-zeit nach Abschluss dieser Ausbildung wehrmann 
+      4.  Hauptfeuer- HFF oder  Abschluss der modularen Grundlagenaus- Hauptfeuer-
+      wehrfrau   HFM  bildung zur Truppführerin oder zum Trupp- wehrfrau  oder  
+      oder   führer und einer dreijährigen Mindestdienst- Hauptfeuer-
+      Hauptfeuer- zeit nach Abschluss dieser Ausbildung  wehrmann 
       wehrmann 
-      5. Erste EHFF Abschluss der modularen Grundlagenaus-Erste Haupt- 
-      Hauptfeuer-oder bildung zur Truppführerin oder zum Trupp-feuerwehrfrau  
-      wehrfrau EHFM führer und eine zehnjährige Mindestdienst-oder  
-      oder  zeit nach Abschluss dieser Ausbildung  Erster Haupt- 
-      Erster feuerwehrmann 
+      5.  Erste  EHFF  Abschluss der modularen Grundlagenaus- Erste Haupt- 
+      Hauptfeuer- oder  bildung zur Truppführerin oder zum Trupp- feuerwehrfrau  
+      wehrfrau  EHFM  führer und eine zehnjährige Mindestdienst- oder  
+      oder   zeit nach Abschluss dieser Ausbildung    Erster Haupt- 
+      Erster  feuerwehrmann 
       Hauptfeuer-
       wehrmann 
       II. Zweite Dienstgradgruppe ,Brandmeisterin oder Brandmeisterʻ 
-      Dienst-Alter Dienstgrad 
-      grad-Dienstgrad Abkürzung Voraussetzungen für die Verleihung nach früherem 
-      stufe Recht 
-      1 2 3 4 5 
-      1. Brandmeis-BM'in Abschluss des Ausbildungslehrgangs Löschmeisterin  
-      terin oder  oder BM  ,Gruppenführerʻ  oder  
-      Brandmeis-Löschmeister 
+      Dienst- Alter Dienstgrad 
+      grad- Dienstgrad  Abkürzung   Voraussetzungen für die Verleihung   nach früherem 
+      stufe  Recht 
+      1  2  3  4  5 
+      1.  Brandmeis- BM'in  Abschluss des Ausbildungslehrgangs  Löschmeisterin   
+      terin oder   oder BM   ,Gruppenführerʻ   oder  
+      Brandmeis- Löschmeister  
       ter 
-      2. Oberbrand- OBM'in Abschluss des Ausbildungslehrgangs Oberlösch- 
-      meisterin  oder OBM  ,Gruppenführerʻ und eine sechsjährige Min-meisterin oder  
-      oder  destdienstzeit nach Abschluss dieser Aus-Oberlösch- 
-      Oberbrand- bildung meister 
+      2.  Oberbrand-  OBM'in  Abschluss des Ausbildungslehrgangs  Oberlösch - 
+      meisterin   oder OBM   ,Gruppenführerʻ und eine sechsjährige Min- meisterin oder  
+      oder   destdienstzeit nach Abschluss dieser Aus- Oberlösch-  
+      Oberbrand-   bildung  meister 
       meister 
-      3. Hauptbrand- HBM'in Abschluss des Ausbildungslehrgangs Hauptlösch-
-      meisterin  oder HBM ,Gruppenführerʻ und eine zwölfjährige Min-meisterin oder  
-      oder  destdienstzeit nach Abschluss dieser Aus-Hauptlösch-
-      Hauptbrand-bildung meister 
+      3.  Hauptbrand-  HBM'in  Abschluss des Ausbildungslehrgangs  Hauptlösch -
+      meisterin   oder HBM  ,Gruppenführerʻ und eine zwölfjährige Min- meisterin oder  
+      oder   destdienstzeit nach Abschluss dieser Aus- Hauptlösch-
+      Hauptbrand- bildung  meister 
       meister 
-      4. Erste EHBM'in Abschluss des Ausbildungslehrgangs Erste Haupt-
-      Hauptbrand-oder ,Gruppenführerʻ und eine achtzehnjährige löschmeisterin  
-      meisterin EHBM Mindestdienstzeit nach Abschluss dieser oder  
-      oder  Ausbildung Erster Haupt-
-      Erster löschmeister 
+      4.  Erste  EHBM'in  Abschluss des Ausbildungslehrgangs  Erste Haupt-
+      Hauptbrand- oder  ,Gruppenführerʻ und eine achtzehnjährige  löschmeisterin   
+      meisterin  EHBM  Mindestdienstzeit nach Abschluss dieser  oder  
+      oder   Ausbildung  Erster Haupt-
+      Erster  löschmeister  
       Hauptbrand-
       meister 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 18 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 18 
        
-      Teil B: Verleihung von Dienstgraden aufgrund der Übertragung einer Regelfunktion  
-      I. Erste Dienstgradgruppe ,Feuerwehrfrau oder Feuerwehrmannʻ 
-      Dienst-Alter Dienstgrad 
-      grad-Dienstgrad Abkürzung Voraussetzungen für die Verleihung nach früherem 
-      stufe Recht 
-      1 2 3 4 5 
-      1. Hauptfeuer-HFF oder a) Gerätebeauftragte oder Gerätebeauftrag-Hauptfeuer-
-      wehrfrau HFM ter wehrfrau  
-      oder  oder  
-      b) Atemschutzbeauftragte oder Atemschutz-
-      Hauptfeuer-Hauptfeuer-
+      Teil B: Verleihung von Dienstgraden aufgrund der Übertragung einer Re gelfunktion  
+      I. Erste Dienstgradgruppe , Feuerwehrfrau oder Feuerwehrmannʻ 
+      Dienst- Alter Dienstgrad 
+      grad- Dienstgrad  Abkürzung   Voraussetzungen für die Verleihung   nach früherem 
+      stufe  Recht 
+      1  2  3  4  5 
+      1.  Hauptfeuer- HFF oder  a)  Gerätebeauftragte oder Gerätebeauftrag- Hauptfeuer-
+      wehrfrau  HFM   ter  wehrfrau  
+      oder   oder  
+      b)  Atemschutzbeauftragte oder Atemschutz-
+      Hauptfeuer- Hauptfeuer-
       beauftragter 
-      wehrmann wehrmann 
-      c) Schriftführerin oder Schriftführer 
-      d) Stellvertretende Gerätewartin oder Stell-
-      vertretender Gerätewart 
-      e) Stellvertretende Atemschutzgerätewartin 
+      wehrmann  wehrmann 
+      c)  Schriftführerin oder Schriftführer  
+      d)  Stellvertretende Gerätewartin oder Stell-
+      vertretender Gerätewart  
+      e)  Stellvertretende Atemschutzgerätewartin 
       oder Stellvertretender Atemschutzgeräte-
       wart 
-      f) Stellvertretende Pressesprecherin oder 
+      f)  Stellvertretende Pressesprecherin oder 
       Stellvertretender Pressesprecher auf 
       Ebene eines Ortsteils 
-      g) Stellvertretende Sicherheitsbeauftragte 
+      g)  Stellvertretende Sicherheitsbeauftragte 
       oder Stellvertretender Sicherheitsbeauf-
       tragter auf Ebene eines Ortsteils 
-      2. Erste EHFF a) Gerätewartin oder Gerätewart Erste Haupt-
-      Haupt- oder feuerwehrfrau  
-      b) Atemschutzgerätewartin oder Atem-
-      feuerwehr-EHFM oder  
-      schutzgerätewart 
-      frau  Erster Haupt-
-      c) Pressesprecherin oder Pressesprecher 
-      oder  feuerwehr-
+      2.  Erste  EHFF  a)  Gerätewartin oder Gerätewart   Erste Haupt-
+      Haupt-  oder  feuerwehrfrau  
+      b)  Atemschutzgerätewartin oder Atem-
+      feuerwehr- EHFM  oder  
+      schutzgerätewart  
+      frau   Erster Haupt-
+      c)  Pressesprecherin oder Pressesprecher 
+      oder   feuerwehr-
       auf Ebene eines Ortsteils 
-      Erster mann 
+      Erster  mann 
        
       Haupt- 
-      d) Sicherheitsbeauftragte oder Sicherheits-
+      d)  Sicherheitsbeauftragte oder Sicherheits-
       feuerwehr-
       beauftragter auf Ebene eines Ortsteils 
       mann 
-      e) Stellvertretende Jugendfeuerwehrwartin 
+      e)  Stellvertretende Jugendfeuerwehrwartin 
       oder Stellvertretender Jugendfeuerwehr-
       wart auf Ebene eines Ortsteils 
-      f) Stellvertretende Kinderfeuerwehrwartin 
+      f)  Stellvertretende Kinderfeuerwehrwartin 
       oder Stellvertretender Kinderfeuerwehr-
       wart auf Ebene eines Ortsteils 
-        
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 19 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 19 
        
       II. Zweite Dienstgradgruppe ,Brandmeisterin oder Brandmeisterʻ 
-      Dienst-Alter Dienstgrad 
-      grad-Dienstgrad Abkürzung Voraussetzungen für die Verleihung nach früherem 
-      stufe Recht 
-      1 2 3 4 5 
-      1. Brandmeis-BM'in oder Stellvertretende Führerin oder Stellvertre-Löschmeisterin 
-      terin  BM  tender Führer der taktischen Einheit oder  
-      oder  ,Selbständiger Truppʻ, ,Staffelʻ oder Löschmeister 
-      Brandmeis-,Gruppeʻ in einer Ortsfeuerwehr 
+      Dienst- Alter Dienstgrad 
+      grad- Dienstgrad  Abkürzung   Voraussetzungen für die Verleihung   nach früherem 
+      stufe  Recht 
+      1  2  3  4  5 
+      1.  Brandmeis- BM'in oder  Stellvertretende Führerin oder Stellvertre- Löschmeisterin 
+      terin   BM   tender Führer der taktischen Einheit  oder  
+      oder   ,Selbständiger Truppʻ , ,Staffelʻ oder  Löschmeister  
+      Brandmeis- ,Gruppeʻ in einer Ortsfeuerwehr 
       ter 
-      2. Oberbrand-OBM'in oder a) Jugendfeuerwehrwartin oder Jugend-Oberlösch- 
-      meisterin OBM  feuerwehrwart auf Ebene eines Orts-meisterin  
-      oder  teils oder  
-      Oberbrand-Oberlösch- 
-      b) Pressesprecherin oder Pressespre-
-      meister meister 
+      2.  Oberbrand- OBM'in oder  a)  Jugendfeuerwehrwartin oder Jugend- Oberlösch - 
+      meisterin  OBM   feuerwehrwart auf Ebene eines Orts- meisterin  
+      oder   teils  oder  
+      Oberbrand- Oberlösch-  
+      b)  Pressesprecherin oder Pressespre-
+      meister  meister 
       cher auf Ebene einer Gemeinde 
-      c) Ausbilderin oder Ausbilder in der 
+      c)  Ausbilderin oder Ausbilder in der 
       Feuerwehr auf Ebene einer Ge-
       meinde 
-      d) Führerin oder Führer der taktischen 
-      Einheit ,Selbständiger Truppʻ, ,Staf-
-      felʻ oder ,Gruppeʻ in einer Ortsfeuer-
+      d)  Führerin oder Führer der taktischen 
+      Einheit ,Selbständiger Truppʻ , ,Staf-
+      felʻ oder ,Gruppeʻ  in einer Ortsfeuer-
       wehr 
-      e) Sicherheitsbeauftragte oder Sicher-
+      e)  Sicherheitsbeauftragte oder Sicher-
       heitsbeauftragter auf Ebene einer 
       Gemeinde 
-      f) Stellvertretende Jugendfeuerwehr-
+      f)  Stellvertretende Jugendfeuerwehr-
       wartin oder Stellvertretender Jugend-
       feuerwehrwart auf Ebene einer Ge-
       meinde 
-      g) Kinderfeuerwehrwartin oder Kinder-
+      g)  Kinderfeuerwehrwartin oder Kinder-
       feuerwehrwart auf Ebene eines Orts-
       teils 
-      h) Stellvertretende Kinderfeuerwehrwar-
+      h)  Stellvertretende Kinderfeuerwehrwar-
       tin oder Stellvertretender Kinderfeu-
       erwehrwart auf Ebene einer Ge-
       meinde 
-      3. Haupt-HBM'in oder a) Jugendfeuerwehrwartin oder  Hauptlösch- 
-      brand- HBM Jugendfeuerwehrwart auf Ebene ei-meisterin  
-      meisterin  ner Gemeinde oder  
-      oder  Hauptlösch- 
-      b) Stellvertretende Ausbildungsleiterin 
-      Haupt-meister 
+      3.  Haupt- HBM'in oder  a)  Jugendfeuerwehrwartin oder   Hauptlösch - 
+      brand-   HBM  Jugendfeuerwehrwart auf Ebene ei- meisterin  
+      meisterin   ner Gemeinde  oder  
+      oder   Hauptlösch-  
+      b)  Stellvertretende Ausbildungsleiterin 
+      Haupt- meister 
       oder Stellvertretender Ausbildungs-
       brandmeis-
       leiter auf Ebene einer Gemeinde 
       ter 
-      c) Pressesprecherin oder Pressespre-
+      c)  Pressesprecherin oder Pressespre-
       cher auf Ebene eines Landkreises  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 20 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 20 
        
-      d) Ausbilderin oder Ausbilder in der 
+      d)  Ausbilderin oder Ausbilder in der 
       Feuerwehr auf Ebene eines Land-
       kreises 
-      e) Sicherheitsbeauftragte oder Sicher-
+      e)  Sicherheitsbeauftragte oder Sicher-
       heitsbeauftragter auf Ebene eines 
       Landkreises 
-      f) Kinderfeuerwehrwartin Kinderfeuer-
+      f)  Kinderfeuerwehrwartin Kinderfeuer-
       wehrwart auf Ebene einer Gemeinde 
-      4. Erste EHBM'in a) Stellvertretende Ortsbrandmeisterin Erste Haupt-
-      Haupt-oder EHBM oder Stellvertretender Ortsbrand-löschmeisterin 
-      brandmeis-meister einer Grundausstattungsfeu-oder  
-      terin  erwehr Erster Haupt-
-      oder  löschmeister 
-      b) Ausbildungsleiterin oder Ausbil-
+      4.  Erste  EHBM'in  a)  Stellvertretende Ortsbrandmeisterin  Erste Haupt-
+      Haupt- oder EHBM  oder Stellvertretender Ortsbrand- löschmeisterin 
+      brandmeis- meister einer Grundausstattungsfeu- oder  
+      terin   erwehr  Erster Haupt-
+      oder   löschmeister  
+      b)  Ausbildungsleiterin oder Ausbil-
       Erster 
       dungsleiter auf Ebene einer Ge-
       Haupt-
       meinde 
       brandmeis-
-      c) Stellvertretende Führerin oder Stell-
+      c)  Stellvertretende Führerin oder Stell-
       ter 
       vertretender Führer der taktischen 
       Einheit ,Zugʻ auf Ebene eines Orts-
-      teils oder einer Gemeinde 
-      III. Dritte Dienstgradgruppe ,Brandinspektorin oder Brandinspektorinʻ 
-      Dienst-Alter Dienstgrad 
-      grad-Dienstgrad Abkürzung Voraussetzungen für die Verleihung nach früherem 
-      stufe Recht 
-      1 2 3 4 5 
-      1. Brandin-BrIin oder a) Ortsbrandmeisterin oder Ortsbrand-Brandmeisterin 
-      spektorin BrI meister einer Grundausstattungsfeu-oder  
-      oder  erwehr Brandmeister 
+      teils oder einer Gem einde 
+      III. Dritte Dienstgradgruppe , Brandinspektorin oder Brandinspektorinʻ 
+      Dienst- Alter Dienstgrad 
+      grad- Dienstgrad  Abkürzung   Voraussetzungen für die Verleihung   nach früherem 
+      stufe  Recht 
+      1  2  3  4  5 
+      1.  Brandin- BrIin oder  a)  Ortsbrandmeisterin oder Ortsbrand- Brandmeisterin 
+      spektorin  BrI  meister einer Grundausstattungsfeu- oder  
+      oder   erwehr  Brandmeister 
       Brandin-
-      b) Stellvertretende Ortsbrandmeisterin 
+      b)  Stellvertretende Ortsbrandmeisterin 
       spektor 
       oder Stellvertretender Ortsbrand-
-      meister einer Stützpunktfeuerwehr 
-      c) Führerin oder Führer der taktischen 
+      meister einer Stützpunktfeuerwehr  
+      c)  Führerin oder Führer der taktischen 
       Einheit ,Zugʻ auf Ebene eines Orts-
       teils oder einer Gemeinde 
-      d) Stellvertretende Ausbildungsleiterin 
+      d)  Stellvertretende Ausbildungsleiterin 
       oder Stellvertretender Ausbildungs-
-      leiter auf Ebene eines Landkreises 
-      e) Stellvertretende Führerin oder Stell-
+      leiter auf Ebene eines Landkreises  
+      e)  Stellvertretende Führerin  oder Stell-
       vertretender Führer der taktischen 
       Einheit ,Zugʻ auf Ebene eines Land-
       kreises 
-      f) Stellvertretende Jugendfeuerwehr-
+      f)  Stellvertretende Jugendfeuerwehr-
       wartin oder Stellvertretender Jugend-
       feuerwehrwart auf Ebene eines 
       Landkreises 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 21 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 21 
        
-      g) Stellvertretende Kinderfeuerwehrwar-
+      g)  Stellvertretende Kinderfeuerwehrwar-
       tin oder Stellvertretender Kinderfeu-
       erwehrwart auf Ebene eines Land-
       kreises 
-      2. Oberbrand- OBrI'In oder a) Ortsbrandmeisterin oder Ortsbrand-Oberbrand-
-      inspektorin  OBrI meister einer Stützpunktfeuerwehr meisterin  
-      oder  oder  
-      b) Stellvertretende Ortsbrandmeisterin 
-      Oberbrand-Oberbrandmeis-
+      2.  Oberbrand-  OBrI'In oder  a)  Ortsbrandmeisterin oder Ortsbrand- Oberbrand-
+      inspektorin   OBrI  meister einer Stützpunktfeuerwehr   meisterin  
+      oder   oder  
+      b)  Stellvertretende Ortsbrandmeisterin 
+      Oberbrand- Oberbrandmeis-
       oder Stellvertretender Ortsbrand-
-      inspektor ter 
+      inspektor  ter 
       meister einer Schwerpunktfeuerwehr  
-      c) Führer oder Führerin der taktischen 
+      c)  Führer oder Führerin der taktischen 
       Einheit ,Zugʻ auf Ebene eines Land-
       kreises 
-      d) Jugendfeuerwehrwartin oder Jugend-
+      d)  Jugendfeuerwehrwartin oder Jugend-
       feuerwehrwart auf Ebene eines 
       Landkreises 
-      e) Kinderfeuerwehrwartin oder Kinder-
+      e)  Kinderfeuerwehrwartin oder Kinder-
       feuerwehrwart auf Ebene eines 
       Landkreises 
-      f) Ausbildungsleiterin oder Ausbil-
+      f)  Ausbildungsleiterin oder Ausbil-
       dungsleiter auf Ebene eines Land-
       kreises 
-      3. Haupt-HBrI'in oder a) Ortsbrandmeisterin oder Ortsbrand-Hauptbrand-
-      brand- HBrI meister einer Schwerpunktfeuerwehr meisterin  
-      inspektorin  oder  
-      b) Stellvertretende Führerin oder Stell-
-      oder  Hauptbrand- 
+      3.  Haupt- HBrI'in oder  a)  Ortsbrandmeisterin oder Ortsbrand- Hauptbrand-
+      brand-   HBrI  meister einer Schwerpunktfeuerwehr  meisterin  
+      inspektorin   oder  
+      b)  Stellvertretende Führerin oder Stell-
+      oder   Hauptbrand-  
       vertretender Führer einer taktischen 
-      Haupt-meister 
+      Haupt- meister 
       Einheit auf Ebene eines Landkreises, 
-      brand- 
+      brand-  
       die aus mehr als einem Zug besteht 
       inspektor 
-      4. Erste EHBrI'in a) Führerin oder Führer einer taktischen Erste Haupt-
-      Haupt-oder EHBrI  Einheit auf Ebene eines Landkreises, brandmeisterin  
-      brand- die aus mehr als einem Zug besteht oder  
-      inspektorin  Erster Haupt-
-      b) Stellvertretende Gemeinde- oder 
-      oder  brandmeister 
+      4.  Erste  EHBrI'in  a)  Führerin oder Führer einer taktischen  Erste Haupt-
+      Haupt- oder EHBrI   Einheit auf Ebene eines Landkreises,  brandmeisterin  
+      brand-   die aus mehr als einem Zug besteht   oder  
+      inspektorin   Erster Haupt-
+      b)  Stellvertretende Gemeinde-  oder 
+      oder   brandmeister 
       Stadtbrandmeisterin oder Stellvertre-
       Erster 
-      tender Gemeinde- oder Stadtbrand-
+      tender Gemeinde-  oder Stadtbrand-
       Haupt-
       meister  
       brandin-
       spektor 
-      5. Gemeinde-  GemBrIin a) Gemeindebrandmeisterin oder Ge-
-      oder Stadt-oder StBrIin  meindebrandmeister,  
-      brand- 
-      oder b) Stadtbrandmeisterin oder Stadtbrand-
+      5.  Gemeinde-   GemBrIin  a)  Gemeindebrandmeisterin oder Ge-
+      oder Stadt- oder StBrIin   meindebrandmeister,  
+      brand-  
+      oder  b)  Stadtbrandmeisterin oder Stadtbrand-
       inspektorin  
       meister 
       GemBrI 
-      oder   
-      oder StBrI  
-      Gemeinde- 
+      oder    
+      oder StBrI   
+      Gemeinde-  
       oder Stadt-
-      brand- 
+      brand-  
       inspektor 
-        
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 22 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 22 
        
       IV. Vierte Dienstgradgruppe ,Brandschutzleiterin oder Brandschutzleiterʻ 
-      Dienst-Alter Dienstgrad 
-      grad-Dienstgrad Abkürzung Voraussetzungen für die Verleihung nach früherem 
-      stufe Recht 
-      1 2 3 4 5 
-      1. Ab-ABrI'in a) Stellvertretende Abschnittsleiterin oder Erste Haupt-
-      schnitts-oder ABrI Stellvertretender Abschnittsleiter  brandmeisterin  
-      brandin-oder  
-      b) Stellvertretende Stadtbrandmeisterin 
-      spektorin  Erster Haupt-
+      Dienst- Alter Dienstgrad 
+      grad- Dienstgrad  Abkürzung   Voraussetzungen für die Verleihung   nach früherem 
+      stufe  Recht 
+      1  2  3  4  5 
+      1.  Ab- ABrI'in  a)  Stellvertretende Abschnittsleiterin oder  Erste Haupt-
+      schnitts- oder ABrI  Stellvertretender Abschnittsleiter   brandmeisterin  
+      brandin- oder  
+      b)  Stellvertretende Stadtbrandmeisterin 
+      spektorin   Erster Haupt-
       oder Stellvertretender Stadtbrandmeis-
-      oder  brandmeister 
-      ter in Städten mit Berufsfeuerwehr 
+      oder   brandmeister 
+      ter in Städten mit Berufsfeuerwehr  
       Ab-
       schnitts-
       brandin-
       spektor 
-      2. Erste Ab-EABrI'in a) Abschnittsleiterin oder Abschnittsleiter Abschnitts-
-      schnitts-oder EABrI brandmeisterin  
-      b) Stellvertretende Stadtbrandmeisterin 
-      brandin-oder  
+      2.  Erste Ab- EABrI'in  a)  Abschnittsleiterin oder Abschnittsleiter  Abschnitts-
+      schnitts- oder EABrI  brandmeisterin  
+      b)  Stellvertretende Stadtbrandmeisterin 
+      brandin- oder  
       oder Stellvertretender Stadtbrandmeis-
-      spektorin Abschnitts-
+      spektorin  Abschnitts-
       ter in kreisfreien Städten ohne Berufs-
-      oder  brandmeister 
+      oder   brandmeister 
       feuerwehr  
       Erster Ab-
-      c) Stadtbrandmeisterin oder Stadtbrand-
+      c)  Stadtbrandmeisterin oder Stadtbrand-
       schnitts-
-      meister in Städten mit Berufsfeuerwehr 
+      meister in Städten mit Berufsfeuerwehr  
       brandin-
       spektor 
-      3. Kreis-KBrI'in a) Stellvertretende Kreisbrandmeisterin Abschnitts-
-      brandin-oder KBrI oder Stellvertretender Kreisbrandmeis-brandmeisterin 
-      spektorin ter,  oder  
-      oder Abschnitts-
-      b) Stadtbrandmeisterin oder Stadtbrand-
-      Kreis-brandmeister 
+      3.  Kreis- KBrI'in  a)  Stellvertretende Kreisbrandmeisterin  Abschnitts-
+      brandin- oder KBrI  oder Stellvertretender Kreisbrandmeis- brandmeisterin 
+      spektorin  ter,   oder  
+      oder  Abschnitts-
+      b)  Stadtbrandmeisterin oder Stadtbrand-
+      Kreis- brandmeister 
       meister in kreisfreien Städten ohne Be-
       brandin-
       rufsfeuerwehr 
       spektor 
-      4. Erste EKBrI'in Kreisbrandmeisterin oder Kreisbrandmeister Kreisbrandmeis-
-      Kreis-oder EKBrI terin oder Kreis-
-      brandin-brandmeister 
+      4.  Erste  EKBrI'in  Kreisbrandmeisterin oder Kreisbrandmeister  Kreisbrandmeis-
+      Kreis- oder EKBrI  terin oder Kreis-
+      brandin- brandmeister 
       spektorin 
       oder  
       Erster 
       Kreis-
       brandin-
       spektor 
-      5. Regie-RegBrI'in Regierungsbrandmeister oder Regierungs-Regierungs-
-      rungs-oder Reg-brandmeisterin brandmeisterin 
-      brandin-BrI oder  
-      spektorin Regierungs-
-      oder  brandmeister. 
+      5.  Regie- RegBrI'in  Regierungsbrandmeister oder Regierungs- Regierungs-
+      rungs- oder Reg- brandmeisterin  brandmeisterin 
+      brandin- BrI  oder  
+      spektorin  Regierungs-
+      oder   brandmeister. 
       Regie-
       rungs-
       brandin-
@@ -1230,538 +1230,538 @@ pages:
        
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 23 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 23 
        
-      14. Die bisherige Anlage 3 wird Anlage 4 und die Bezeichnung des Klammerzusatzes erhält folgende  
+      14.   Die bisherige Anlage  3 wird Anlage  4 und die  Bezeichnung des Klammerzusatzes erhält folgende   
       Fassung: 
       (zu § 12). 
-      15. Die bisherige Anlage 4 wird Anlage 5 und erhält folgende Fassung: 
+      15.   Die bisherige Anlage 4 wird Anlage 5 und erhält folgende Fassung:  
       Anlage 5  
       (zu § 12) 
-      Dienstkleidung für Mitglieder der Niedersächsischen Feuerwehren 
+      Dienstkleidung für Mitglieder der Niedersächsischen Feuerwehren  
       Zu repräsentativen Anlässen tragen Mitglieder der Freiwilligen Feuerwehr und der Pflichtfeuerwehr 
-      die Schirmmütze nach Teil A und die Dienstkleidung zur Ausübung dienstlicher Tätigkeit mit repräsen-
+      die Schirmmütze nach Teil  A und die Dienstkleidung zur Ausübung dienstlicher Tätigkeit mit repräsen-
       tativem Anlass nach Teil C. Während der Übungsdienste und in Ausübung sonstiger dienstlicher Tätig-
-      keit dürfen sie, wenn nicht die persönliche Ausrüstung nach Anlage 4 zu tragen ist, die Schirmmütze 
-      nach Teil A oder eine Kopfbedeckung nach Teil D Nr. 9 oder 10 und die Tagesdienstkleidung nach 
-      Teil D tragen. Die Wetterschutzkleidung nach Teil E wird über der Dienstkleidung getragen.  
-      Teil A: Schirmmütze 
-      Mützenteil Beschreibung 
-      Mützen- 
-      körper 
+      keit dürfen sie, wenn nicht die persönliche Ausrüstung nach Anl age  4 zu tragen ist, die Schirmmütze 
+      nach Teil A oder eine Kopfbedeckung nach Teil  D Nr.  9 oder 10 und die Tagesdienstkleidung nach 
+      Teil  D tragen. Die Wetterschutzkleidung nach Teil E wird über der Dienstkleidung getragen.   
+      Teil A: Schirmmütze  
+      Mützenteil   Beschreibung 
+      Mützen-  
+      körper  
        
-       runde Ausführung 
-       Baumwollgemisch mit punktierten Reflexband 
-       dunkelblau 
-       eine untere Druckknopfhälfte oder Platz für einen Splint zur Befestigung des  
+        runde Ausführung  
+        Baumwollgemisch mit punktierten Reflexband 
+        dunkelblau 
+        eine untere Druckknopfhälfte oder Platz für einen Splint zur Befestigung des   
       Feuerwehremblems (oder Kokarde) 
-       zwei untere Druckknopfhälften oder Platz für bis zu zwei Splinte zur Befestigung 
+        zwei untere Druckknopfhälften oder Platz für bis zu zwei Splinte zur Befestigung 
       des Landesemblems  
-       zwei untere Druckknopfhälften oder Platz für zwei Mützensplinte zur Befestigung 
+        zwei untere Druckknopfhälften oder Platz f ür zwei Mützensplinte zur Befestigung 
       der Mützenkordel 
-        
+         
     images:
       - page_22_image_0.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 24 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 24 
        
-      Feuer- 
+      Feuer-  
       wehr- 
       emblem 
        
-       Das Feuerwehremblem besteht aus der altsilberfarbigen Darstellung eines Feu-
+        Das Feuerwehremblem besteht aus der altsilberfarbigen Darstellung eines Feu-
       erwehrhelms mit Kinnriemen und Nackenleder und einer hinter dem Helm mit ei-
       nem Feuerwehrbeil gekreuzten Picke.  
-       Es wird am oberen Rand der Schirmmütze in der Mitte des Vorderteils auf den 
+        Es wird am oberen Rand der Schirmmütze in der Mitte des Vorderteils  auf den 
       zur Montage angebrachten unteren Druckknopfhälften oder dem Platzhalter ge-
       tragen 
-       Die Beamtinnen und Beamten des Feuerwehrdienstes können anstatt des Feu-
+        Die Beamtinnen und Beamten des Feuerwehrdienstes können anstatt des Feu-
       erwehremblems eine schwarz-rot-goldene Kokarde tragen. 
-       In der Dienstgradgruppe ,Brandschutzleiterinnen oder Brandschutzleiterʻ und in 
-      den Sonderdienstgraden nach § 11 Abs. 10 wird ein goldfarbiges Feuerweh-
+        In der Dienstgradgruppe ,Brandschutzleiterinnen oder Brandschutzleiterʻ und in 
+      den Sonderdienstgraden nach §  11 Abs. 10 wird ein goldfarbiges Feuerweh-
       remblem getragen. 
-      Landes- 
+      Landes-  
       emblem 
        
-       Das Landesemblem führt das Niedersachsenross in silberfarbiger Darstellung 
-      auf rotem Untergrund. 
-       Größe des Landesemblems: 18 mm (Breite) x 21 mm (Höhe) 
-       Das Landesemblem ist umgeben von einem 5 mm breiten, oben offenen Kranz 
+        Das Landesemblem führt das Niedersachsenross in silberfarbiger Darstellung 
+      auf rotem Untergrund.  
+        Größe des Landesemblems: 18 mm (Breite) x 21 mm (Höhe)  
+        Das Landesemblem ist umgeben von einem 5 mm breiten, oben offenen Kranz 
       aus metallenen Eichenblättern. Der Kranz ist auf beiden Seiten von 
-      mehrflächigen, der Mützenform entsprechend nach innen gebogenen, 
+      mehrflächigen, der Mützenform entsprechend nac h innen gebogenen, 
       metallenen Flügeln begrenzt.  
-       Das Abzeichen ist aus Emaille Tombak und aus altsilberfarbigem Metall 
+        Das Abzeichen ist aus Emaille Tombak und aus altsilberfarbigem Metall 
       hergestellt und mit farblosem Lack überzogen. Auf der Rückseite sind zwei 
-      obere Druckknopfhälften bzw. Durchstechsplinte angebracht. 
-       Es wird in der Mitte der Mütze mittig zwischen dem Feuerwehremblem und der 
-      Mützenkordel getragen. 
+      obere Druckknopfhälften bzw. Durchstechsplinte angebracht.  
+        Es wird in der Mitte der Mütze mittig zwischen dem Feuerwehremblem und der 
+      Mützenkordel getragen.  
         In der Dienstgradgruppe ,Brandschutzleiterinnen oder Brandschutzleiterʻ und in 
-      den Sonderdienstgraden nach § 11 Abs. 10 wird das Landesemblem auf einem 
+      den Sonderdienstgraden nach §  11 Abs. 10 wird das Landesemblem auf einem 
       Abzeichen aus goldfarbigem Metall mit dem Niedersachsenross in 
       metallgoldfarbiger Darstellung auf rotem Untergrund getragen. 
-        
+         
     images:
       - page_23_image_0.jpg
       - page_23_image_1.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 25 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 25 
        
-      Mützen-Erste Dienstgradgruppe ,Feuerwehrfrau oder Feuerwehrmannʻ: 
+      Mützen- Erste Dienstgradgruppe ,Feuerwehrfrau oder Feuerwehrmannʻ: 
       kordel 
-      – tzkd,et,cz,cs ,zweiilrfbig
+      –  tzkd,et,cz,cs  ,zweiilrfbig
       k tzsplieodrkkti. 
-      Zwteistar ,Brdistindraistʻ: 
-       Mützenkordel, gedreht, silberfarbig, Durchmesser 6 mm, an zwei silberfarbig ge-
-      körnten Mützensplinten oder Druckknöpfen befestigt. 
-      Dritte Dienstgradgruppe ,Brandinspektorin oder Brandinspektorʻ: 
-       Mützenkordel, gedreht, silberfarbig, Durchmesser 8 mm, an zwei silberfarbig ge-
-      körnten Mützensplinten oder Druckknöpfen befestigt. 
-      Vierte Dienstgradgruppe ,Brandschutzleiterin oder Brandschutzleiterʻ und Sonderdienst-
-      grad nach § 11 Abs. 10: 
-       Mützenkordel, gedreht, goldfarbig, Durchmesser 8 mm, an zwei goldfarbig ge-
-      körnten Mützensplinten oder Druckknöpfen befestigt. 
-      Teil B: Schriftzug ,Feuerwehrʻ 
+      Zwteistar , Brdistindraistʻ: 
+        Mützenkordel, gedreht, silberfarbig, Durchmesser 6  mm, an zwei silberfarbig ge-
+      körnten Mützensplinten oder Druckknöpfen bef estigt. 
+      Dritte Dienstgradgruppe , Brandinspektorin oder Brandinspektorʻ: 
+        Mützenkordel, gedreht, silberfarbig, Durchmesser 8  mm, an zwei silberfarbig ge-
+      körnten Mützensplinten oder Druckknöpfen befestigt . 
+      Vierte Dienstgradgruppe , Brandschutzleiterin oder Brandschutzleiterʻ und Sonderdienst-
+      grad nach § 11 Abs. 10:  
+        Mützenkordel, gedreht, goldfarbig, Durchmesser 8  mm, an zwei goldfarbig ge-
+      körnten Mützensplinten oder Druckknöpfen befestigt.  
+      Teil B: Schriftzug ,Feuerwehrʻ  
       Wenn in den Teilen C bis E eine abweichende Regelung nicht getroffen ist, wird der nachstehend 
       abgebildete Schriftzug ,Feuerwehrʻ auf der Dienstkleidung auf der linken Brustseite der Oberbekleidung 
-      getragen: 
+      getragen:  
       . 
-      Teil C: Dienstkleidung zu repräsentativem Anlass 
-      Dienstkleidung zur Ausübung dienstlicher Tätigkeit mit repräsentativem Anlass 
-      Nr. Teil der Dienstkleidung Beschreibung 
-      1. a) Uniformjacke für  Stoff aus Mischgewebe 
-      männliche Mitglieder 
-       dunkelblau 
-       einreihig 
-       Herrenschnitt mit drei Knöpfen zum Durchknöpfen 
-       Knöpfe silberfarbig, Hammerschlagoberfläche oder gekörnt 
-       zwei blinde Paspeltaschen beidseitig  
-       Schriftzug ,Feuerwehrʻ unterhalb der linken Paspeltasche 
-       zwei eingesetzte Seitentaschen mit Patten  
-       ab Dienstgrad ,Abschnittsbrandinspektorinʻ oder ,Abschnitts-
+      Teil C: Dienstkleidung zu repräsentativem Anlass  
+      Dienstkleidung zur Ausübung dienstlicher Tätigkeit mit repräsentativem Anlass  
+      Nr.  Teil der Dienstkleidung  Beschreibung 
+      1.  a) Uniformjacke für    Stoff aus Mischgewebe 
+      männliche Mitglieder  
+        dunkelblau 
+        einreihig 
+        Herrenschnitt mit drei Knöpfen zum Durchknöpfen  
+        Knöpfe silberfarbig, Hammerschlagoberfläche oder gekörnt  
+        zwei blinde Paspeltaschen beidseitig  
+        Schriftzug ,Feuerwehrʻ unterhalb der linken Paspeltasche 
+        zwei eingesetzte Seitentaschen mit Patten  
+        ab Dienstgrad , Abschnittsbrandinspektorinʻ oder ,Abschnitts-
       brandinspektorʻ Knöpfe goldfarbig, Hammerschlagoberfläche 
-      oder gekörnt 
-       Wappen werden auf dem linken Oberärmel getragen, mit Är-
+      oder gekörnt  
+        Wappen werden auf dem linken Oberärmel getragen, mit Är-
       melflausch 
-       Gewebetunnel links und rechts zur Aufnahme der Schulter-
+        Gewebetunnel links und rechts zur Aufnahme der Schulter-
       klappen 
     images:
       - page_24_image_0.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 26 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 26 
        
        
-      b) Uniformjacke für  Stoff aus Mischgewebe 
+      b) Uniformjacke für    Stoff aus Mischgewebe 
       weibliche Mitglieder 
-       dunkelblau 
-       einreihig 
-       Damenschnitt mit drei Knöpfen zum Durchknöpfen 
-       Knöpfe silberfarbig, Hammerschlagoberfläche oder gekörnt 
-       Kragen aus Jackenstoff für offene Trageweise 
-       zwei blinde Paspeltaschen beidseitig  
-       Schriftzug ,Feuerwehrʻ unterhalb der linken Paspeltasche 
-       zwei eingesetzte Seitentaschen mit Patten  
-       ab Dienstgrad ,Abschnittsbrandinspektorinʻ oder ,Abschnitts-
+        dunkelblau 
+        einreihig 
+        Damenschnitt mit drei Knöpfen zum Durchknöpfen  
+        Knöpfe silberfarbig, Hammerschlagoberfläche oder gekörnt  
+        Kragen aus Jackenstoff für offene Trageweise  
+        zwei blinde Paspeltaschen beidseitig  
+        Schriftzug ,Feuerwehrʻ unterhalb der linken Paspeltasche 
+        zwei eingesetzte Seitentaschen mit Patten  
+        ab Dienstgrad , Abschnittsbrandinspektorinʻ  oder ,Abschnitts-
       brandinspektorʻ Knöpfe goldfarbig, Hammerschlagoberfläche 
-      oder gekörnt 
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+      oder gekörnt  
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch 
-       Gewebetunnel links und rechts zur Aufnahme der Schulter-
+        Gewebetunnel links und rechts zur Aufnahme der Schulter-
       klappen 
-      2. a) Hose für männliche  im gleichen Stoff und in der gleichen Farbe wie die Uniform- 
-      Mitglieder jacke nach Nummer 1 Buchst. a  
-       Herrenschnitt   
-       Gürtelschlaufen 
-       zwei Seitentaschen als Flügeltaschen 
-       eine Gesäßtasche rechts als Paspeltasche 
+      2.  a) Hose für männliche    im gleichen Stoff und in der gleichen Farbe wie die Uniform- 
+      Mitglieder  jacke nach Nummer 1 Buchst. a  
+        Herrenschnitt   
+        Gürtelschlaufen  
+        zwei Seitentaschen als Flügeltaschen  
+        eine Gesäßtasche rechts als Paspeltasche  
        
-      b) Hose für weibliche  im gleichen Stoff und in der gleichen Farbe wie die Uniform- 
-      Mitglieder jacke nach Nummer 1 Buchst. b 
-       Damenschnitt  
-       Gürtelschlaufen 
-       zwei Seitentaschen als Flügeltaschen 
+      b) Hose für weibliche    im gleichen Stoff und in der gleichen Farbe wie die Uniform- 
+      Mitglieder  jacke nach Nummer 1 Buchst. b 
+        Damenschnitt  
+        Gürtelschlaufen  
+        zwei Seitentaschen als Flügeltaschen  
        
-      c) Rock für weibliche  im gleichen Stoff und in der gleichen Farbe wie die Uniform- 
-      Mitglieder jacke nach Nummer 1 Buchst. b 
-      (Alternativ zu   gerader Schnitt 
+      c) Rock für weibliche    im gleichen Stoff und in der gleichen Farbe wie die Uniform- 
+      Mitglieder  jacke nach Nummer 1 Buchst. b 
+      (Alternativ zu     gerader Schnitt 
       Nummer 2 Buchst. b) 
-       knielang  
-       Bewegungsschlitz hinten  
-      3. a) Hemd lang für   weiß 
-      männliche Mitglieder 
-       1/1 Armlänge 
-       Kentkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       nach Festlegung des Trägers der Feuerwehr zusätzliche Pas-
+        knielang  
+        Bewegungsschlitz hinten  
+      3.  a) Hemd lang für      weiß  
+      männliche Mitglieder  
+        1/1 Armlänge  
+        Kentkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        nach Festlegung des Trägers der Feuerwehr zusätzliche Pas-
       peltasche linksseitig 
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 27 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 27 
        
-       Gewebetunnel links und rechts zur für Schulterklappenadapter 
+        Gewebetunnel links und rechts zur für Schulterklappenadapter 
       zur Aufnahme der Überziehschlaufen; alternativ Schulterklap-
-      pen zur Aufnahme der Überziehschlaufen 
+      pen zur Aufnahme der Überziehschlaufen  
        
-      b) Bluse lang für   weiß 
+      b) Bluse lang für      weiß  
       weibliche Mitglieder 
-       1/1 Armlänge 
-       Blusenkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+        1/1 Armlänge  
+        Blusenkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter zur 
+        Gewebetunnel links und rechts für Schulterklappenadapter z ur 
       Aufnahme der Überziehschlaufen; alternativ Schulterklappen 
-      zur Aufnahme der Überziehschlaufen 
-      4. a) Hemd kurz für   weiß 
-      männliche Mitglieder 
-       1/2 Armlänge 
-       Kentkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       nach Festlegung des Trägers der Feuerwehr zusätzliche Pas-
+      zur Aufnahme der Überziehschlaufen  
+      4.  a) Hemd kurz für      weiß  
+      männliche Mitglieder  
+        1/2 Armlänge  
+        Kentkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        nach Festlegung des Trägers der Feuerwehr zusätzliche Pas-
       peltasche linksseitig  
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter zur 
+        Gewebetunnel links und rechts für Schulterklappenadapter zur 
       Aufnahme der Überziehschlaufen; alternativ Schulterklappen 
-      zur Aufnahme der Überziehschlaufen 
+      zur Aufnahme der Überziehschlaufen  
        
-      b) Bluse kurz für   weiß 
+      b) Bluse kurz für      weiß  
       weibliche Mitglieder 
-       1/2 Armlänge 
-       Blusenkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+        1/2 Armlänge  
+        Blusenkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter zur 
+        Gewebetunnel links und rechts für Schulterklappenadapter zur 
       Aufnahme der Überziehschlaufen; alternativ Schulterklappen 
-      zur Aufnahme der Überziehschlaufen 
-      5. a) Schuhe für   schwarz 
-      männliche Mitglieder 
-       Halbschuhe 
+      zur Aufnahme der Überziehschlaufen  
+      5.  a) Schuhe für      schwarz 
+      männliche Mi tglieder 
+        Halbschuhe 
        
-      b) Schuhe für   schwarz 
+      b) Schuhe für      schwarz 
       weibliche Mitglieder 
-       Halbschuhe oder Pumps 
-      6. Socken  schwarz  
-      7. Krawatte  in der gleichen Farbe wie Uniformjacke nach Nummer 1 
+        Halbschuhe oder Pumps 
+      6.  Socken    schwarz  
+      7.  Krawatte    in der gleichen Farbe wie Uniformjacke nach Nummer 1 
       Buchst. a ohne Aufdrucke 
-      8. Gürtel  Ledergürtel (oder Alternativmaterial in Lederoptik) 
-       schwarz 
-       40 mm breit 
+      8.  Gürtel     Ledergürtel (oder  Alternativmaterial in Lederoptik) 
+        schwarz 
+        40 mm breit 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 28 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 28 
        
       Teil D: Tagesdienstkleidung  
       Tagesdienstkleidung 
-      Nr. Teil der Dienstkleidung Beschreibung  
-        1. a) Arbeitsjacke für   dunkelblau 
-      männliche Mitglieder 
-       Herrenschnitt 
-       Zwei-Wege-Reißverschluss, abgedeckt  
-       zwei paspelierte Brusttaschen mit Reißverschluss 
-       Schriftzug ,Feuerwehrʻ auf der linken Brustseite 
-       Ärmelabschluss mit Reißverschluss zur Weitenregulierung 
-       Saumabschluss mit Kordel zur Weitenregulierung 
-       Wappen werden auf dem linken Oberärmel getragen, mit 
+      Nr.  Teil der Dienstkleidung  Beschreibung  
+        1.  a) Arbeitsjacke für      dunkelblau 
+      männliche Mitglieder  
+        Herrenschnitt 
+        Zwei-Wege- Reißverschluss, abgedeckt   
+        zwei paspelierte Brusttaschen mit Reißverschluss  
+        Schriftzug ,Feuerwehrʻ auf der linken Brustseite 
+        Ärmelabschluss mit Reißverschluss zur Weitenregulierung  
+        Saumabschluss mit Kordel zur Weitenregulierung 
+        Wappen werden auf dem linken Oberärmel getragen, mit 
       Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von Über-
+        Schulterklappen links und rechts zur Aufnahme von Über-
       ziehschlaufen 
        
-      b) Arbeitsjacke für   dunkelblau 
+      b) Arbeitsjacke für      dunkelblau 
       weibliche Mitglieder 
-       Damenschnitt 
-       Zwei-Wege-Reißverschluss, abgedeckt  
-       zwei paspelierte Brusttaschen mit Reißverschluss 
-       Schriftzug ,Feuerwehrʻ auf der linken Brustseite  
-       Ärmelabschluss mit Reißverschluss zur Weitenregulierung 
-       Saumabschluss mit Kordel zur Weitenregulierung 
-       Wappen werden auf dem linken Oberärmel getragen, mit 
+        Damenschnitt 
+        Zwei-Wege- Reißverschluss, abgedeckt   
+        zwei paspelierte Brusttaschen mit Reißverschluss  
+        Schriftzug ,Feuerwehrʻ auf der linken Brustseite  
+        Ärmelabschluss mit Reißverschluss zur Weitenregulierung  
+        Saumabschluss mit Kordel zur Weitenregulierung 
+        Wappen werden auf dem linken Oberärmel getragen, mit 
       Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von Über-
+        Schulterklappen links und rechts zur Aufnahme von Über-
       ziehschlaufen 
-        2.  a) Softshelljacke für  dunkelblau 
-      männliche Mitglieder 
-       Herrenschnitt 
-       Reißverschluss, abgedeckt  
-       unter der Reißverschlussabdeckung eine Napoleontasche 
-       zwei Brusttaschen mit Patten mit Klettflauschverschluss 
-       Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
-       zwei schräge Leistentaschen mit Reißverschluss 
-       Ärmelabschluss mit Manschette zur Weitenregulierung 
-       nach Festlegung des Trägers der Feuerwehr mit Kapuze 
-       Wappen werden auf dem linken Oberärmel getragen, mit 
+        2.   a) Softshelljacke für    dunkelblau 
+      männliche Mitglieder  
+        Herrenschnitt 
+        Reißverschluss, abgedeckt  
+        unter der Reißverschlussabdeckung eine Napoleontasche 
+        zwei Brusttaschen mit Patten mit Klettflauschverschluss 
+        Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
+        zwei schräge Leistentaschen mit Reißverschluss  
+        Ärmelabschluss mit Manschette zur Weitenregulierung 
+        nach Festlegung des Trägers der Feuerwehr mit Kapuze 
+        Wappen werden auf dem linken Oberärmel getragen, mit 
       Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von Über-
+        Schulterklappen links und rechts zur Aufnahme von Über-
       ziehschlaufen 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 29 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 29 
        
-       b) Softshelljacke für  dunkelblau 
+        b) Softshelljacke für    dunkelblau 
       weibliche Mitglieder 
-       Damenschnitt 
-       Reißverschluss, abgedeckt  
-       unter der Reißverschlussabdeckung eine Napoleontasche 
-       zwei Brusttasche mit Patten mit Klettflauschverschluss 
-       Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
-       zwei schräge Leistentaschen mit Reißverschluss 
-       Ärmelabschluss mit Manschette zur Weitenregulierung 
-       nach Festlegung des Trägers der Feuerwehr mit Kapuze 
-       Wappen werden auf dem linken Oberärmel getragen,  
+        Damenschnitt 
+        Reißverschluss, abgedeckt  
+        unter der Reißverschlussabdeckung eine Napoleontasche 
+        zwei Brusttasche mit Patten mit Klettflauschverschluss 
+        Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
+        zwei schräge Leistentaschen mit Reißverschluss  
+        Ärmelabschluss mit Manschette zur Weitenregulierung 
+        nach Festlegung des Trägers der Feuerwehr mit Kapuze 
+        Wappen werden auf dem linken Oberärmel getragen,   
       mit Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von  
-      Überziehschlaufen 
-        3. a) Blouson für   dunkelblau 
-      männliche Mitglieder 
-       Herrenschnitt 
-       Reißverschluss, abgedeckt  
-       unter der Reißverschlussabdeckung eine Napoleontasche 
-       zwei Brusttaschen mit Patten mit Klettflauschverschluss 
-       Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
-       zwei schräge Leistentaschen 
-       Ärmelabschluss mit Manschette zur Weitenregulierung 
-       Saumabschluss mit Blousonbündchen mit seitlichen  
-      Gummizügen 
-       Wappen werden auf dem linken Oberärmel getragen,  
+        Schulterklappen links und rechts zur Aufnahme von  
+      Überziehschlaufen  
+        3.  a) Blouson für      dunkelblau 
+      männliche Mitglieder  
+        Herrenschnitt 
+        Reißverschluss, abgedeckt  
+        unter der Reißverschlussabdeckung eine Napoleontasche 
+        zwei Brusttaschen mit Patten mit Klettflauschverschluss 
+        Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
+        zwei schräge Leistentaschen  
+        Ärmelabschluss mit Manschette zur Weitenregulierung 
+        Saumabschluss mit Blousonbündchen mit seitlichen   
+      Gummizügen  
+        Wappen werden auf dem linken Oberärmel getragen,   
       mit Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von  
-      Überziehschlaufen 
+        Schulterklappen links und rechts zur Aufnahme von  
+      Überziehschlaufen  
        
-      b) Blouson für   dunkelblau 
+      b) Blouson für      dunkelblau 
       weibliche Mitglieder 
-       Damenschnitt 
-       Reißverschluss, abgedeckt  
-       unter der Reißverschlussabdeckung eine Napoleontasche 
-       zwei Brusttaschen mit Patten mit Klettflauschverschluss 
-       Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
-       zwei schräge Leistentaschen 
-       Ärmelabschluss mit Manschette zur Weitenregulierung 
-       Saumabschluss mit Blousonbündchen mit seitlichen  
-      Gummizügen 
-       Wappen werden auf dem linken Oberärmel getragen,  
+        Damenschnitt 
+        Reißverschluss, abgedeckt  
+        unter der Reißverschlussabdeckung eine Napoleontasche 
+        zwei Brusttaschen mit Patten mit Klettflauschverschluss 
+        Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche  
+        zwei schräge Leistentaschen  
+        Ärmelabschluss mit Manschette zur Weitenregulierung 
+        Saumabschluss mit Blousonbündchen mit seitlichen   
+      Gummizügen  
+        Wappen werden auf dem linken Oberärmel getragen,   
       mit Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von  
-      Überziehschlaufen 
+        Schulterklappen links und rechts zur Aufnahme von  
+      Überziehschlaufen  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 30 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 30 
        
-        4. Strickjacke  dunkelblau 
-       Reißverschluss 
-       aufstellbarer Kragen 
-       Brusttasche links mit Patte 
-       Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche 
-       Ärmelabschluss zur Längenregulierung 
-       Schultern, Seitennähte und Unterarme durch Gewebebe-
-      satz verstärkt 
-       Wappen werden auf dem linken Oberärmel getragen,  
+        4.  Strickjacke    dunkelblau 
+        Reißverschluss  
+        aufstellbarer Kragen 
+        Brusttasche links mit Patte 
+        Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche 
+        Ärmelabschluss zur Längenregulierung  
+        Schultern, Seitennähte und Unterarme durch Gewebebe-
+      satz verstärkt  
+        Wappen werden auf dem linken Oberärmel getragen,   
       mit Ärmelflausch 
-       Schulterklappen links und rechts zur Aufnahme von Über-
+        Schulterklappen links und rechts zur Aufnahme von Über-
       ziehschlaufen 
-        5. a) Hose für   dunkelblau 
-      männliche Mitglieder 
-       Herrenschnitt 
-       Cargohose  
-       zwei schräge Leistentaschen vorne 
-       zwei Gesäßtaschen mit Knopfverschluss 
-       zwei seitlich auf den Hosenbeinen aufgesetzte Taschen mit 
+        5.  a)  Hose für      dunkelblau 
+      männliche Mitglieder  
+        Herrenschnitt 
+        Cargohose  
+        zwei schräge Leistentaschen vorne  
+        zwei Gesäßtaschen mit Knopfverschluss  
+        zwei seitlich auf den Hosenbeinen aufgesetzte Taschen mit 
       Patten und verdeckten Druckknöpfen oder Klettverschluss  
-       nach Festlegung des Trägers der Feuerwehr mit Bundwei-
+        nach Festlegung des Trägers der Feuerwehr mit  Bundwei-
       tenregulierung 
        
-      b) Hose für   dunkelblau 
+      b)  Hose für      dunkelblau 
       weibliche Mitglieder 
-       Damenschnitt  
-       Cargohose  
-       zwei schräge Leistentaschen vorne 
-       zwei Gesäßtaschen mit Knopfverschluss 
-       zwei seitlich auf den Hosenbeinen aufgesetzte Taschen mit  
-      Patten und verdeckten Druckknöpfen oder Klettverschluss  
-        6. a) Hemd lang für   weiß oder dunkelblau 
-      männliche Mitglieder 
-       1/1 Armlänge 
-       Kentkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       nach Festlegung des Trägers der Feuerwehr zusätzliche  
+        Damenschnitt  
+        Cargohose  
+        zwei schräge Leistentaschen vorne  
+        zwei Gesäßtaschen mit Knopfverschluss  
+        zwei seitlich auf den Hosenbeinen aufgesetzte Taschen mit  
+      Patten und verdeckten Druckknöpfen oder  Klettverschluss  
+        6.  a)  Hemd lang für      weiß oder dunkelblau  
+      männliche Mitglieder  
+        1/1 Armlänge  
+        Kentkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        nach Festlegung des Trägers der Feuerwehr zusätzliche   
       Paspeltasche linksseitig  
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter 
+        Gewebetunnel links und rechts für Schulterklappenadapter 
       zur Aufnahme der Überziehschlaufen; alternativ Schulter-
-      klappen zur Aufnahme der Überziehschlaufen 
+      klappen zur Aufnahme der Überziehschlaufen  
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 31 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 31 
        
        
-      b) Bluse lang für   weiß oder dunkelblau 
+      b)  Bluse lang für      weiß oder  dunkelblau 
       weibliche Mitglieder 
-       1/1 Armlänge 
-       Blusenkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       Wappen werden auf dem linken Oberärmel getragen, mit 
+        1/1 Armlänge  
+        Blusenkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        Wappen werden auf dem linken Oberärmel getragen, mit 
       Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter 
+        Gewebetunnel links und rechts für Schulterklappenadapter 
       zur Aufnahme der Überziehschlaufen; alternativ Schulter-
-      klappen zur Aufnahme der Überziehschlaufen 
-        7. a) Hemd kurz für   weiß oder dunkelblau 
-      männliche Mitglieder 
-       1/2 Armlänge 
-       Kentkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       nach Festlegung des Trägers der Feuerwehr zusätzliche 
+      klappen zur Aufnahme der Überziehschlaufen  
+        7.  a)  Hemd kurz für      weiß oder dunkelblau  
+      männliche Mitglieder  
+        1/2 Armlänge  
+        Kentkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        nach Festlegung des Trägers der Feuerwehr zusätzliche 
       Paspeltasche linksseitig  
-       Wappen werden auf dem linken Oberärmel getragen, mit  
+        Wappen werden auf dem linken Oberärmel getragen, mit   
       Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter 
+        Gewebetunnel links und rechts für Schulterklappenadapter 
       zur Aufnahme der Überziehschlaufen; alternativ Schulter-
-      klappen zur Aufnahme der Überziehschlaufen 
+      klappen zur Aufnahme der Überziehschlaufen  
        
-      b) Bluse kurz für   weiß oder dunkelblau 
+      b) Bluse kurz für      weiß oder dunkelblau  
       weibliche Mitglieder 
-       1/2 Armlänge 
-       Blusenkragen 
-       zwei aufgesetzte Brusttaschen mit Knopfverschluss 
-       Wappen werden auf dem linken Oberärmel getragen,  
+        1/2 Armlänge  
+        Blusenkragen 
+        zwei aufgesetzte Brusttaschen mit Knopfverschluss 
+        Wappen werden auf dem linken Oberärmel getragen,   
       mit Ärmelflausch  
-       Gewebetunnel links und rechts für Schulterklappenadapter 
+        Gewebetunnel links und rechts für Schulterklappenadapter 
       zur Aufnahme der Überziehschlaufen; alternativ Schulter-
-      klappen zur Aufnahme der Überziehschlaufen 
-        8. Weitere Oberteile  T-Shirt, Polo-Shirt, Sweat-Shirt, Baumwollpullover oder  
-      Fleecejacke nach Festlegung des Trägers der Feuerwehr 
-       dunkelblau 
+      klappen zur Aufnahme der Überziehschlaufen  
+        8.  Weitere Oberteile    T-Shirt, Polo-Shirt, Sweat-Shirt, Baumwollpullover oder  
+      Fleecejacke  nach Festlegung des Trägers der Feuerwehr  
+        dunkelblau 
         Schriftzug ,Feuerwehrʻ 
-       Rückseite: nach Festlegung des Trägers der Feuerwehr 
+        Rückseite: nach Festlegung des Trägers der Feuerwehr 
       weißer Schriftzug  ,Feuerwehrʻ und Name der jeweiligen 
       Kommune,  
       Freiwillige Feuerwehr und Name der jeweiligen Kommune, 
       Werkfeuerwehr und Name der jeweiligen Kommune,  
       Berufsfeuerwehr und Name der jeweiligen Kommune 
-        9. Wollmütze  Strickausführung  
-       dunkelblau  
-       Schriftzug ,Feuerwehrʻ 
+        9.  Wollmütze     Strickausführung   
+        dunkelblau  
+        Schriftzug ,Feuerwehrʻ 
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 32 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 32 
        
-      10. Base-Cap  dunkelblau 
-       amerikanische Baseball-Capform 
-       mit langem Schirm 
-       Schriftzug ,Feuerwehrʻ  
-       verstellbarer Verschluss zur Größenregulierung 
-      11. Schuhe  schwarz  
-       Halbschuhe oder Sicherheitsschuhe 
-      12. Socken  schwarz  
-      13. Gürtel  Ledergürtel (oder Alternativmaterial in Lederoptik) 
-       schwarz 
-       40 mm oder 45 mm breit 
+      10.  Base-Cap    dunkelblau 
+        amerikanische Baseball-Capform 
+        mit langem Schirm 
+        Schriftzug ,Feuerwehrʻ  
+        verstellbarer Verschluss zur Größenregulierung  
+      11.  Schuhe    schwarz  
+        Halbschuhe oder Sicherheitsschuhe 
+      12.  Socken    schwarz  
+      13.  Gürtel     Ledergürtel (oder Alternativmaterial in Lederoptik)  
+        schwarz 
+        40 mm oder 45 mm breit 
       Teil E: Wetterschutzkleidung 
       Die Wetterschutzkleidung beinhaltet eine Langjacke mit folgender Gestaltung: 
-       wasserdampfdurchlässige, wasser- und winddichte Membrane, 
-       dunkelblauer Oberstoff, 
-       Herrenschnitt, 
-       Reißverschluss bis zum Stehkragen, verdeckte Druckknöpfe, 
-       zwei Brusttaschen mit abgeschrägten Patten und verdeckten Druckknöpfen, 
-       Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche,  
-       zwei Leistentaschen, 
-       Innentaschen links und rechts mit Reißverschluss, 
-       abnehmbare Kapuze, 
-       Wappen werden auf dem linken Oberärmel getragen, mit Ärmelflausch, 
-       Schulterschlaufen links und rechts zur Aufnahme von Überziehschlaufen. 
-      16. Die bisherige Anlage 5 wird Anlage 6 und wie folgt geändert: 
-      a) Die Bezeichnung des Klammerzusatzes erhält folgende Fassung: 
+        wasserdampfdurchlässige, wasser - und winddichte Membrane,  
+        dunkelblauer Oberstoff, 
+        Herrenschnitt, 
+        Reißverschluss bis zum Stehkragen, verdeckte Druckknöpfe,  
+        zwei Brusttaschen mit abgeschrägten Patten und verdeckten Druckknöpfen,  
+        Schriftzug ,Feuerwehrʻ auf der Patte der linken Brusttasche,   
+        zwei Leistentaschen,  
+        Innentaschen links und rechts mit Reißverschluss , 
+        abnehmbare Kapuze,  
+        Wappen werden auf dem linken Oberärmel getragen, mit Ärmelflausch,  
+        Schulterschlaufen links und rechts zur Aufnahme von Überziehschlaufen.  
+      16.   Die bisherige Anlage  5 wird Anlage 6 und wie folgt geändert:  
+      a)  Die Bezeichnung des Klammerzusatzes erhält folgende Fassung:  
       (zu § 12). 
-      b) In der Überschrift werden nach den Worten Freiwilligen Feuerwehren die Worte und Pflichtfeu-
-      erwehren eingefügt. 
-        
+      b)  In der Überschrift werden nach den W orten  Freiwilligen Feuerwehren die Worte und Pflichtfeu-
+      erwehren eingefügt.  
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 33 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 33 
        
-      17. Anlage 7 erhält folgende Fassung: 
-      Anlage 7  
-      (zu § 13) 
+      17.   Anlage  7 erhäl t folgende Fassung: 
+      Anlage 7   
+      (zu § 13)  
       Dienstgradabzeichen der Freiwilligen Feuerwehren und Pflichtfeuerwehren 
       Dienstgradabzeichen werden als bestickte Schulterklappen oder bestickte Überziehschlaufen getra-
       gen.  
-      Nicht maßstabgetreue Beispiele für bestickte Schulterklappe und bestickte Überziehschlaufe: 
-      1. Bestickte Schulterklappe 
+      Nicht maßstabgetreue Beispiele für bestickte Schulterklappe und bestickte Überziehschlaufe:  
+      1.  Bestickte Schulterklappe 
       . 
-      2. Bestickte Überziehschlaufe 
-       . 
-      Schulterklappen werden auf der Uniformjacke für weibliche Mitglieder (Anlage 5 Teil C 
-      Nr. 1 Buchst. b) und auf der Uniformjacke für männliche Mitglieder (Anlage 5 Teil C Nr. 1 Buchst. a) 
+      2.  Bestickte Überziehschlaufe  
+        . 
+      Schulterklappen werden auf der Uniformjacke für weibliche Mitglieder (Anlage 5 Teil  C 
+      Nr. 1 Buchst. b) und auf der Uniformjacke für männliche Mitglieder (Anlage 5 Teil  C Nr.  1 Buchst. a) 
       getragen. 
-      Auf dem Blouson für weibliche Mitglieder (Anlage 5 Teil D Nr. 3 Buchst. b) und dem Blouson für 
-      männliche Mitglieder (Anlage 5 Teil D Nr. 3 Buchst. a) werden entweder Schulterklappen oder Über-
+      Auf dem Blouson für weibliche Mitglieder (Anlage 5 Teil  D Nr.  3 Buchst. b) und dem Blouson für 
+      männliche Mitglieder (Anlage 5 Teil  D Nr.  3 Buchst. a) werden entweder Schulterklappen oder Über-
       ziehschlaufen getragen. 
       Auf der sonstigen Dienstkleidung nach Anlage 5 können nach Festlegung des Trägers der Feuer-
-      wehr Überziehschlaufen getragen werden, wenn das Kleidungsstück eine Aufnahme für Dienstgradab-
+      wehr Ü berziehschlaufen getragen werden, wenn das Kleidungsstück eine Aufnahme für Dienstgradab-
       zeichen vorsieht. 
       Die Schulterklappen werden in gerader Längsseite, spitz zulaufend zur Schulter entsprechend der 
       Beschreibung und bildlichen Darstellung in der nachfolgenden Tabelle getragen. Die zu stickenden ro-
-      ten, silber- oder goldfarbigen Elemente der Schulterklappen werden mit metallisiertem Stickgarn aus-
+      ten, silber- oder goldfarbigen  Elemente der Schulterklappen werden mit metallisiertem Stickgarn aus-
       geführt. Die aufzubringenden Symbole (Eichenlaub in kleiner und großer Form, Balken, Sterne und 
       Umrandung) sind symmetrisch zur Längsachse anzuordnen. Die Stärke der dargestellten Balken be-
-      trägt 4 mm. Sie haben eine Breite von 18 mm. Sterne haben einen Durchmesser von etwa 12 mm. Die 
-      rote Umrandung hat eine Stärke von mindestens 1 mm, höchstens 2 mm. Bei der Aufbringung von meh-
-      reren Balken ist der Abstand zwischen den Balken von 4 mm einzuhalten.  
-      Die Breite der Schulterklappe beträgt 50 mm. Für die sichtbaren Außenflächen der Schulterklappen 
-      ist das Oberstoffmaterial als dunkelblaues Baumwollmischgewebe in Anlehnung an die Jacken und Ho-
+      trägt 4  mm. Sie haben eine Breite von 18  mm. Sterne haben einen Durchmesser von etwa 12  mm. Die 
+      rote Umrandung hat eine Stärke von mindestens 1  mm, höchstens 2  mm. Bei der Aufbringung von meh-
+      reren Balken ist der Abstand zwischen den Balken von 4  mm einzuhalten.  
+      Die Breite der Schulterklappe beträgt 50  mm. Für die sichtbaren Außenflächen der Schulterklappen 
+      ist das Oberstoffmaterial als dunkelblaues Baumwollmischgewebe in Anlehnung  an die Jacken und Ho-
       sen zu nutzen. Die Innenflächen sind mit schwarzem oder dunkelblauem Filz zu belegen. Die gesamte 
-      Länge der auseinander gelegten Klappe beträgt etwa 235 mm. Sie wird zur Fixierung bei etwa der Hälfte 
-      der Länge geknickt und doppelt gelegt. Ober- und Untertritt sind am Ende mit einer 90 Grad gewinkelten, 
+      Länge der auseinander gelegten Klappe beträgt etwa 235  mm. Sie wird zur Fixierung bei etwa der Hälfte 
+      der Länge geknickt und doppelt gelegt. Ober - und Untertritt sind am Ende mit einer 90 Grad gewinkelten, 
       spitzen Ausführung zu fertigen. Der Obertritt der Jackenschulterklappe ist mit einer Astraloneinlage oder 
-      gleichwertiger Art zu versteifen. Im Bereich der Spitze sind Ober- und Untertritt mit einem Druckknopf, 
-      Metall, Durchmesser 15 mm, silber- oder goldfarbig, fixierbar auszustatten. Zum Tragen der 
+      gleichwertiger Art zu versteifen. Im Bereich der Spitze sind Ober - und Untertritt mit einem Druckknopf, 
+      Metall, Durchmesser 15  mm, silber -  oder goldfarbig, fixierbar auszustatten. Zum Tragen der 
     images:
       - page_32_image_0.jpg
       - page_32_image_1.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 34 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 34 
        
       Dienstgradabzeichen auf vorheriger Uniform ist anstelle des Druckknopfes ein Durchlass von etwa 
-      20 mm zu schaffen. Der Durchlass ist so zu gestalten, dass er sich nicht weiten oder reißen kann.  
+      20  mm zu schaffen. Der Durchlass ist so zu gestalten, dass er sich nicht weiten oder reißen kann.   
       Die Überziehschlaufen werden ohne Druckknopfnachbildung und ohne Spitze entsprechend der bild-
-      lichen Darstellung getragen. Die zu stickenden roten, silber- oder goldfarbigen Elemente der Überzieh-
-      schlaufen werden mit metallisiertem Stickgarn ausgeführt. Die aufzubringenden Symbole (Eichenlaub 
+      lichen Darstellung getragen. Die zu stickenden roten, silber- oder goldfarbigen Elemente  der Überzieh-
+      schlaufen werden mit metallisiertem Stickgarn ausgeführt. Die  aufzubringenden Symbole (Eichenlaub 
       in kleiner und großer Form, Balken, Sterne und Umrandung) sind symmetrisch zur Längsachse anzu-
-      ordnen. Die Stärke der dargestellten Balken beträgt 4 mm. Sie haben eine Breite von 18 mm. Sterne 
-      haben einen Durchmesser von etwa 12 mm. Die rote Umrandung hat eine Stärke von mindestens 1 mm, 
-      höchstens 2 mm. Bei der Aufbringung von mehreren Balken ist der Abstand zwischen den Balken von 
+      ordnen. Die Stärke der dargestellten Balken beträgt 4  mm. Sie haben eine Breite von 18  mm. Sterne 
+      haben einen Durchmesser von etwa 12  mm. Die rote Umrandung hat eine Stärke von mindestens 1  mm, 
+      höchstens 2  mm. Bei der Aufbringung von mehreren Balken ist der Abstand zwischen den Balken von 
       4 mm einzuhalten.  
-      Die Überziehschlaufen sind als Rechteck mit einer Kantenlänge von 90 mm mal 55 mm auszuge-
+      Die Überziehschlaufen sind als Rechteck mit einer Kantenlänge von 90  mm mal 55  mm auszuge-
       stalten. Als Stoffmaterial ist dunkelblaues Baumwollmischgewebe in Anlehnung an die Jacken und Ho-
-      sen zu nutzen. Die Umrandung des abgebildeten Dienstgrades erfolgt in rotem, silber- oder goldfarbi-
-      gem Stickgarn als Rechteck parallel zu den Außenkanten.  
+      sen zu nutzen. Die Umrandung des abgebildeten Dienstgrades erfolgt in rotem, silber - oder goldfarbi-
+      gem Stickgarn als Rechteck parallel zu den Außenkanten.   
       Zur Befestigung von Überziehschlaufen auf Kleidungsstücken mit Gewebetunnel sind Schulteradap-
-      ter in gleicher Farbe wie das Kleidungsstück zulässig. Die Breite des Adapters soll 40 mm nicht über-
-      schreiten. Die gesamte Länge des auseinandergelegten Adapters ist etwa 230 mm. Die Ausführung 
-      kann mit Druckknopf (15 mm) oder Knopf (15 mm) mit Durchlass erfolgen.  
-      I. Erste Dienstgradgruppe ,Feuerwehrfrau oder Feuerwehrmannʻ 
-      1 2 3 4 
+      ter in gleicher Farbe wie das Kleidungsstück zulässig. Die Breite des Adapters soll 40  mm nicht über-
+      schreiten. Die gesamte Länge des auseinandergelegt en Adapters ist etwa 230  mm. Die Ausführung 
+      kann mit Druckknopf (15  mm) oder Knopf (15  mm) mit Durchlass erfolgen.  
+      I. Erste Dienstgradgruppe , Feuerwehrfrau oder Feuerwehrmannʻ 
+      1  2  3  4 
       Beschreibung des 
-      Nr. Dienstgrad Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Nr.  Dienstgrad  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       chens 
-      1. Feuerwehrfrau- Schulterklappe 
-      anwärterin  oder 
-      oder  Überziehschlaufe 
-      Feuerwehrmann-mit stilisiertem 
-      anwärter Eichenlaub in 
+      1.  Feuerwehrfrau-  Schulterklappe 
+      anwärterin    oder 
+      oder   Überziehschlaufe 
+      Feuerwehrmann- mit stilisiertem 
+      anwärter   Eichenlaub in 
       kleiner Form, rot, 
       ein roter Balken 
       und eine schmale 
-      rote Linie als  
+      rote Linie als   
       Umrandung 
-      2. Feuerwehrfrau  wie Nummer 1 
-      oder  dieser 
-      Feuerwehrmann Dienstgradgruppe, 
+      2.  Feuerwehrfrau   wie Nummer 1 
+      oder   dieser 
+      Feuerwehrmann  Dienstgradgruppe, 
       jedoch mit zwei 
       roten Balken 
        
@@ -1770,35 +1770,35 @@ pages:
       - page_33_image_1.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 35 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 35 
        
-      3. Oberfeuerwehrfrau wie Nummer 1 
-      oder  dieser 
-      Oberfeuerwehr-Dienstgradgruppe, 
-      mann jedoch mit drei 
+      3.  Oberfeuerwehrfrau  wie Nummer 1 
+      oder   dieser 
+      Oberfeuerwehr- Dienstgradgruppe, 
+      mann  jedoch mit drei 
       roten Balken 
        
-      4. Hauptfeuerwehr-wie Nummer 1 
-      frau oder  dieser 
-      Hauptfeuerwehr-Dienstgradgruppe, 
-      mann jedoch mit vier 
+      4.  Hauptfeuerwehr- wie Nummer 1 
+      frau oder   dieser 
+      Hauptfeuerwehr- Dienstgradgruppe, 
+      mann  jedoch mit vier 
       roten Balken 
        
-      5. Erste  wie Nummer 1 
-      Hauptfeuerwehr-dieser 
-      frau  Dienstgradgruppe, 
-      oder  jedoch mit vier 
-      Erster  roten Balken und 
-      Hauptfeuerwehr-einem roten Stern 
+      5.  Erste   wie Nummer 1 
+      Hauptfeuerwehr- dieser 
+      frau   Dienstgradgruppe, 
+      oder   jedoch mit vier 
+      Erster   roten Balken und 
+      Hauptfeuerwehr- einem roten Stern 
       mann 
        
-      II. Zweite Dienstgradgruppe Brandmeisterin oder Brandmeister 
-      1 2 3 4 
+      II. Zweite Dienstgradgruppe Brandmeisterin oder Brandmeister  
+      1  2  3  4 
       Beschreibung des 
-      Nr. Dienstgrad Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Nr.  Dienstgrad  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       chens 
-      1. Brandmeisterin Schulterklappe 
-      oder Brandmeister oder Überzieh-
+      1.  Brandmeisterin  Schulterklappe 
+      oder Brandmeister  oder Überzieh-
       schlaufe mit stili-
       siertem Eichen-
       laub in kleiner 
@@ -1806,7 +1806,7 @@ pages:
       zwei silberfarbi-
       gen Balken und 
       eine schmale rote 
-      Linie als  
+      Linie als   
       Umrandung 
     images:
       - page_34_image_0.jpg
@@ -1815,43 +1815,43 @@ pages:
       - page_34_image_3.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 36 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 36 
        
-      2. Oberbrand- wie Nummer 1 
-      meisterin oder  dieser Dienstgrad-
-      Oberbrandmeister gruppe, jedoch mit 
+      2.  Oberbrand-  wie Nummer 1 
+      meisterin oder   dieser Dienstgrad-
+      Oberbrandmeister  gruppe, jedoch mit 
       drei silberfarbigen 
       Balken 
        
-      3. Hauptbrand- wie Nummer 1 
-      meisterin oder  dieser Dienstgrad-
-      Hauptbrandmeister gruppe, jedoch mit 
+      3.  Hauptbrand-  wie Nummer 1 
+      meisterin oder   dieser Dienstgrad-
+      Hauptbrandmeister  gruppe, jedoch mit 
       vier silberfarbigen 
       Balken 
        
-      4. Erste  wie Nummer 1 
-      Hauptbrand- dieser Dienstgrad-
-      meisterin  gruppe, jedoch mit 
-      oder  vier silberfarbigen 
-      Erster  Balken und einem 
-      Hauptbrandmeister silberfarbigen 
+      4.  Erste   wie Nummer 1 
+      Hauptbrand-   dieser Dienstgrad-
+      meisterin   gruppe, jedoch mit 
+      oder   vier silberfarbigen 
+      Erster   Balken und einem 
+      Hauptbrandmeister  silberfarbigen 
       Stern 
        
-      III. Dritte Dienstgradgruppe ,Brandinspektorin oder Brandinspektorʻ 
-      1 2 3 4 
+      III. Dritte Dienstgradgruppe , Brandinspektorin oder Brandinspektorʻ 
+      1  2  3  4 
       Beschreibung des 
-      Nr. Dienstgrad Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Nr.  Dienstgrad  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       chens 
-      1. Brandinspektorin Schulterklappe 
-      oder  oder Überzieh-
-      Brandinspektor schlaufe mit stili-
+      1.  Brandinspektorin  Schulterklappe 
+      oder   oder Überzieh-
+      Brandinspektor  schlaufe mit stili-
       siertem Eichen-
       laub in großer 
       Form, silberfarbig, 
       zwei silberfarbi-
       gen Balken und 
       eine schmale rote 
-      Linie als  
+      Linie als   
       Umrandung 
     images:
       - page_35_image_0.jpg
@@ -1860,35 +1860,35 @@ pages:
       - page_35_image_3.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 37 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 37 
        
-      2. Oberbrand- wie Nummer 1 
-      inspektorin  dieser Dienstgrad-
-      oder  gruppe, jedoch mit 
-      Oberbrand- drei silberfarbigen 
-      inspektor Balken 
+      2.  Oberbrand-  wie Nummer 1 
+      inspektorin   dieser Dienstgrad-
+      oder   gruppe, jedoch mit 
+      Oberbrand-   drei silberfarbigen 
+      inspektor  Balken 
        
-      3. Hauptbrand- wie Nummer 1 
-      inspektorin  dieser Dienstgrad-
-      oder  gruppe, jedoch mit 
-      Hauptbrand- vier silberfarbigen 
-      inspektor Balken 
+      3.  Hauptbrand-  wie Nummer 1 
+      inspektorin   dieser Dienstgrad-
+      oder   gruppe, jedoch mit 
+      Hauptbrand-   vier silberfarbigen 
+      inspektor  Balken 
        
-      4. Erste  wie Nummer 1 
-      Hauptbrand- dieser Dienstgrad-
-      inspektorin  gruppe, jedoch mit 
-      oder  vier silberfarbigen 
-      Erster  Balken und einem 
-      Hauptbrand- silberfarbigen 
-      inspektor Stern 
+      4.  Erste   wie Nummer 1 
+      Hauptbrand-   dieser Dienstgrad-
+      inspektorin   gruppe, jedoch mit 
+      oder   vier silberfarbigen 
+      Erster   Balken und einem 
+      Hauptbrand-   silberfarbigen 
+      inspektor  Stern 
        
-      5. Gemeinde- oder wie Nummer 1 
-      Stadtbrand- dieser Dienstgrad-
-      inspektorin  gruppe, jedoch mit 
-      oder  vier silberfarbigen 
-      Gemeinde- oder Balken und zwei 
-      Stadtbrand- silberfarbigen 
-      inspektor Sternen 
+      5.  Gemeinde- oder  wie Nummer 1 
+      Stadtbrand-   dieser Dienstgrad-
+      inspektorin   gruppe, jedoch mit 
+      oder   vier silberfarbigen 
+      Gemeinde-  oder  Balken und zwei 
+      Stadtbrand-   silberfarbigen 
+      inspektor  Sternen 
        
     images:
       - page_36_image_0.jpg
@@ -1897,41 +1897,41 @@ pages:
       - page_36_image_3.png
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 38 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 38 
        
       IV. Vierte Dienstgradgruppe ,Brandschutzleiterin oder Brandschutzleiterʻ 
-      1 2 3 4 
+      1  2  3  4 
       Beschreibung des 
-      Nr. Dienstgrad Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Nr.  Dienstgrad  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       chens 
-      1. Abschnittsbrand- Schulterklappe 
-      inspektorin  oder Überzieh-
-      oder  schlaufe mit stili-
-      Abschnittsbrandin-siertem Eichen-
-      spektor laub in großer 
+      1.  Abschnittsbrand-  Schulterklappe 
+      inspektorin   oder Überzieh-
+      oder   schlaufe mit stili-
+      Abschnittsbrandin- siertem Eichen-
+      spektor  laub in großer 
       Form, goldfarbig, 
       zwei goldfarbigen 
       Balken und eine 
-      schmale rote Linie  
+      schmale rote Linie   
       als Umrandung 
-      2. Erste Abschnitts-wie Nummer 1 
-      brandinspektorin dieser Dienstgrad-
-      oder  gruppe, jedoch mit 
-      Erster Abschnitts-drei goldfarbigen 
-      brandinspektor Balken 
+      2.  Erste Abschnitts- wie Nummer 1 
+      brandinspektorin  dieser Dienstgrad-
+      oder   gruppe, jedoch mit 
+      Erster Abschnitts- drei goldfarbigen 
+      brandinspektor  Balken 
        
-      3. Kreisbrand- wie Nummer 1 
-      inspektorin  dieser Dienstgrad-
-      oder  gruppe, jedoch mit 
-      Kreisbrand- vier goldfarbigen 
-      inspektor Balken 
+      3.  Kreisbrand-  wie Nummer 1 
+      inspektorin   dieser Dienstgrad-
+      oder   gruppe, jedoch mit 
+      Kreisbrand-   vier goldfarbigen 
+      inspektor  Balken 
        
-      4. Erste Kreisbrandin-wie Nummer 1 
-      spektorin  dieser Dienstgrad-
-      oder  gruppe, jedoch mit 
-      Erster  vier goldfarbigen 
-      Kreisbrand- Balken und einem 
-      inspektor goldfarbigen Stern 
+      4.  Erste Kreisbrandin- wie Nummer 1 
+      spektorin   dieser Dienstgrad-
+      oder   gruppe, jedoch mit 
+      Erster   vier goldfarbigen 
+      Kreisbrand-   Balken und einem 
+      inspektor  goldfarbigen Stern 
        
     images:
       - page_37_image_0.jpg
@@ -1940,24 +1940,24 @@ pages:
       - page_37_image_3.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 39 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 39 
        
-      5. Regierungsbrand- wie Nummer 1 
-      inspektorin  dieser Dienstgrad-
-      oder  gruppe, jedoch mit 
-      Regierungsbrand- vier goldfarbigen 
-      inspektor Balken und zwei 
+      5.  Regierungsbrand-  wie Nummer 1 
+      inspektorin   dieser Dienstgrad-
+      oder   gruppe, jedoch mit 
+      Regierungsbrand-   vier goldfarbigen 
+      inspektor  Balken und zwei 
       goldfarbigen Ster-
       nen 
        
       V. Sonderdienstgrad 
-      1 2 3 
+      1  2  3 
       Beschreibung des 
-      Dienstgrad Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Dienstgrad  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       chens 
-      Landesbrandinspektorin Schulterklappe 
-      oder  oder Überzieh-
-      Landesbrandinspektor schlaufe mit stili-
+      Landesbrandinspektorin  Schulterklappe 
+      oder   oder Überzieh-
+      Landesbrandinspektor  schlaufe mit stili-
       siertem Eichen-
       laub in großer 
       Form, goldfarbig, 
@@ -1969,134 +1969,134 @@ pages:
       schmale rote Linie 
       als Umrandung 
        
-        
+         
     images:
       - page_38_image_0.jpg
       - page_38_image_1.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 40 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 40 
        
-      18. Anlage 8 erhält folgende Fassung: 
+      18.   Anlage  8 erhält folgende Fassung:  
       Anlage 8 
       (zu § 13) 
-      Kennzeichnung und Gestaltung der persönlichen Ausrüstung  
+      Kennzeichnung und Gestaltung der persönlichen Ausrüstung   
       der Mitglieder der Freiwilligen Feuerwehr und Pflichtfeuerwehr 
       Teil A  
       Feuerwehrhelmkennzeichnung nach Ausbildung 
-      Kennzeichnung Voraussetzung 
-      roter Punkt,  Mitglied mit Abschluss des Ausbildungslehrgangs ,Atemschutzgeräteträgerʻ u 
-      oder  wtAd Atectzrrinn Atectzr
-      schwarzes ,Aʻ  trrwDV 7   
-      grüner Punkt,  Mitglied mit Abschluss des Ausbildungslehrgangs ,Chemikalienschutzanzugträgerʻ 
-      oder  wtArn AtectzrrinAtectzre-
-      schwarzes ,CSAʻ  trrwDV 7   
-      ein roter Streifen Mitglied mit Abschluss des Ausbildungslehrgangs ,Gruppenführerʻ  
+      Kennzeichnung  Voraussetzung 
+      roter Punkt,   Mitglied mit Abschluss des Ausbildungslehrgangs ,Atemschutzgeräteträgerʻ u 
+      oder   wtAd Atectzrrinn Atectzr
+      schwarzes ,Aʻ   trrwDV 7    
+      grüner Punkt,    Mitglied mit Abschluss des Ausbildungslehrgangs ,Chemikalienschutzanzugträgerʻ 
+      oder   wtArn AtectzrrinAtectzre-
+      schwarzes ,CSAʻ  trrwDV 7    
+      ein roter Streifen  Mitglied mit Abschluss des Ausbildungslehrgangs ,Gruppenführerʻ  
       auf beiden  
       Helmseiten 
       zwetreifetgli tcs Aldlrg ,Zfrʻ 
       f 
       Heit 
-      roti tgliit Acs Aldlrg ,Vsfrʻ  
+      roti  tgliit Acs Aldlrg ,Vsfrʻ  
       i CkalisctzatrinChikisctzaträristinzzlic 
       Kchnalstsctzrrindtectzrric frlic 
       DiKchnfgtctenr Afüu: 
-       Strf: lgnmoch 
-       Ri hh. 
+        Strf:  lgnmoch 
+        Ri  hh.  
       Teil B  
       Feuerwehrhelmkennzeichnung nach Regelfunktion 
-      Kennzeichnung  Voraussetzung 
-      zwei rote Ringe Regelfunktion als stellvertretende Abschnittsleiterin oder stellvertretender Ab-
+      Kennzeichnung   Voraussetzung 
+      zwei rote Ringe  Regelfunktion als stellvertretende Abschnittsleiterin oder stellvertretender Ab-
       schnittsleiter, Abschnittsleiterin oder Abschnittsleiter, stellvertretende Kreisbrand-
       meisterin oder stellvertretender Kreisbrandmeister, Kreisbrandmeisterin oder 
       Kreisbrandmeister, Regierungsbrandmeisterin oder Regierungsbrandmeister   
        
-        
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 41 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 41 
        
       Teil C  
       Funktionsweste und Funktionskoller  
-      Gestaltung und Kennzeichnung der  wahrzunehmende einsatzspezifische Funktion oder Aufgabe 
-      Funktionsweste und Funktionskoller im Einsatz  
-      gelbe Funktionsweste oder gelbes Funkti-Einsatzleiterin oder Einsatzleiter 
-      onskoller mit schwarzer Aufschrift ,Ein-
+      Gestaltung und Kennzeichnung der   wahrzunehmende einsatzspezifische Funktion oder Aufgabe 
+      Funktionsweste und Funktionskoller  im Einsatz  
+      gelbe Funktionsweste oder gelbes Funkti- Einsatzleiterin oder Einsatzleiter 
+      onskoller mit schwarzer Aufschrift , Ein-
       satzleiterʻ auf der Front- und Rückseite 
-      der Weste in ein- oder zweizeiliger Form 
-      weiße Funktionsweste oder weißes Funk-Einsatzabschnittsleiterin oder Einsatzabschnittsleiter 
-      tionskoller mit schwarzer Aufschrift ,Ein-
+      der Weste in ein-  oder zweizeiliger Form 
+      weiße Funktionsweste oder weißes Funk- Einsatzabschnittsleiterin oder Einsatzabschnittsleiter 
+      tionskoller mit schwarzer Aufschrift , Ein-
       satzabschnittsleiterʻ auf der Front- und 
-      Rückseite der Weste in ein- oder zweizei-
+      Rückseite der Weste in ein-  oder zweizei-
       liger Form 
-      rot-weiß karierte Funktionsweste oder rot-Verbandsführerin oder Verbandsführer 
+      rot-weiß karierte Funktionsweste oder rot - Verbandsführerin oder Verbandsführer  
       weiß kariertes Funktionskoller mit schwar-
       zer Aufschrift ,Verbandsführerʻ und Name 
       der taktischen Einheit auf der Front- und 
-      Rückseite der Weste in ein- oder zweizei-
+      Rückseite der Weste in ein-  oder zweizei-
       liger Form 
-      rote Funktionsweste oder rotes Funktions-Zugführerin oder Zugführer 
-      koller mit schwarzer Aufschrift ,Zugführerʻ 
+      rote Funktionsweste oder rotes Funktions- Zugführerin oder Zugführer  
+      koller mit schwarzer Aufschrift , Zugführerʻ 
       und Name der taktischen Einheit auf der 
-      Front- und Rückseite der Weste in ein- 
+      Front- und Rückseite der Weste in ein-  
       oder zweizeiliger Form 
-      blaue Funktionsweste oder blaues Funkti-Führerin oder Führer der taktischen Einheit Gruppe oder 
-      onskoller mit schwarzer Aufschrift der Staffel oder Selbständiger Trupp   
+      blaue Funktionsweste oder blaues Funkti- Führerin oder Führer der taktischen Einheit Gruppe oder 
+      onskoller mit schwarzer Aufschrift der  Staffel oder Selbständiger Trupp   
       Ortsfeuerwehr und Kurzbezeichnung des 
       Fahrzeugs auf der Front- und Rückseite 
-      der Weste in ein- oder zweizeiliger Form 
-      grüne Funktionsweste oder grünes Funk-Pressesprecherin oder Pressesprecher 
-      tionskoller mit schwarzer Aufschrift ,Pres-
+      der Weste in ein-  oder zweizeiliger Form 
+      grüne Funktionsweste oder grünes Funk- Pressesprecherin oder Pressesprecher 
+      tionskoller mit schwarzer Aufschrift , Pres-
       sesprecherʻ auf der Front- und Rückseite 
-      der Weste in ein- oder zweizeiliger Form 
-      grün-weiß karierte Funktionsweste oder Fachberaterin oder Fachberater 
-      grün-weiß kariertes Funktionskoller mit 
+      der Weste in ein-  oder zweizeiliger Form 
+      grün -weiß karierte Funktionsweste oder  Fachberaterin oder Fachberater 
+      grün- weiß kariertes Funktionskoller mit 
       Aufschrift ,Fachberaterʻ auf der Front- und 
-      Rückseite der Weste in ein- oder zweizei-
+      Rückseite der Weste in ein-  oder zweizei-
       liger Form 
-      violette Funktionsweste oder violettes Notfallseelsorgerin oder Notfallseelsorger. 
+      violette Funktionsweste oder violettes  Notfallseelsorgerin oder Notfallseelsorger. 
       Funktionskoller mit schwarzer Aufschrift 
       ,Notfallseelsorgerʻ oder ,Kriseninterven-
       tionʻ auf der Front- und Rückseite der 
-      Weste in ein- oder zweizeiliger Form 
+      Weste in ein-  oder zweizeiliger Form 
        
-        
+         
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 42 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 42 
        
-      19. Anlage 9 erhält folgende Fassung: 
+      19.   Anlage 9 erhält folgende Fassung:  
       Anlage 9 
-      (zu § 14 Satz 1) 
+      (zu § 14 Satz 1)  
       Dienstgradabzeichen der Beamtinnen und Beamten des Feuerwehrdienstes 
       Dienstgradabzeichen werden als bestickte Schulterklappen oder bestickte Überziehschlaufen getra-
       gen.  
-      Nicht maßstabgetreue Beispiele für bestickte Schulterklappe und bestickte Überziehschlaufe: 
-      1. Bestickte Schulterklappe 
+      Nicht maßstabgetreue Beispiele für bestickte Schulterklappe und bestickte Überziehschlaufe:  
+      1.  Bestickte Schulterklappe 
       .
-      2. Bestickte Überziehschlaufe 
+      2.  Bestickte Überziehschlaufe  
       . 
-      Schulterklappen werden auf der Uniformjacke für weibliche Mitglieder (Anlage 5 Teil C Nr. 1 
-      Buchst. b) und auf der Uniformjacke für männliche Mitglieder (Anlage 5 Teil C Nr. 1 Buchst. a) getragen. 
-      Auf dem Blouson für weibliche Mitglieder (Anlage 5 Teil D Nr. 3 Buchst. b) und dem Blouson für 
-      männliche Mitglieder (Anlage 5 Teil D Nr. 3 Buchst. a) werden entweder Schulterklappen oder Über-
+      Schulterklappen werden auf der Uniformjacke  für weibliche Mitglieder (Anlage 5 Teil  C Nr.  1 
+      Buchst. b) und auf der Uniformjacke für männliche Mitglieder (Anlage 5 Teil  C Nr.  1 Buchst. a) getragen. 
+      Auf dem Blouson für weibliche Mitglieder (Anlage 5 Teil  D Nr.  3 Buchst. b) und dem Blouson für 
+      männlic he Mitglieder (Anlage 5 Teil  D Nr.  3 Buchst. a) werden entweder Schulterklappen oder Über-
       ziehschlaufen getragen. 
-      Auf der sonstigen Dienstkleidung nach Anlage 5 können nach Festlegung des Trägers der Feuer-
+      Auf der sonstigen Dienstkleidung  nach Anlage  5 können nach Festlegung des Trägers der Feuer-
       wehr Überziehschlaufen getragen werden, wenn das Kleidungsstück eine Aufnahme für Dienstgradab-
       zeichen vorsieht. 
       Die Schulterklappen werden in gerader Längsseite, spitz zulaufend zur Schulter entsprechend der 
       Beschreibung und bildlichen Darstellung in der nachfolgenden Tabelle getragen. Die zu stickenden ro-
-      ten, silber- oder goldfarbigen Elemente der Schulterklappen werden mit metallisiertem Stickgarn aus-
+      ten, silber- oder goldfarbigen  Elemente der Schulterklappen werden mit metallisiertem Stickgarn aus-
       geführt. Die aufzubringenden Symbole (Eichenlaub in kleiner und großer Form, Balken, Sterne und 
       Umrandung) sind symmetrisch zur Längsachse anzuordnen. Die Stärke der dargestellten Balken be-
-      trägt 4 mm. Sie haben eine Breite von 18 mm. Sterne haben einen Durchmesser von etwa 12 mm. 
-      Wenn für das Dienstgradabzeichen eine Umrandung vorgesehen ist, ist diese mindestens 1 mm, höchs-
-      tens 2 mm stark. Bei der Aufbringung von mehreren Balken ist der Abstand zwischen den Balken von 
+      trägt 4  mm. Sie haben eine Breite von 18  mm. Sterne haben einen Durchmesser von etwa 12  mm. 
+      Wenn für das Dienstgradabzeichen eine Umrandung vorgesehen ist, ist diese mindestens 1  mm, höchs-
+      tens 2  mm stark. Bei der Aufbringung von mehreren Balken ist der Abstand zwischen den Balken von 
       4 mm einzuhalten.  
-      Die Breite der Schulterklappe beträgt 50 mm. Für die sichtbaren Außenflächen der Schulterklappen 
+      Die Breite der Schulterklappe beträgt 50  mm. Für die sichtbaren Außenflächen der Schulterklappen 
       ist das Oberstoffmaterial als dunkelblaues Baumwollmischgewebe in Anlehnung an die Jacken und Ho-
       sen zu nutzen. Die Innenflächen sind mit schwarzem oder dunkelblauem Filz zu belegen. Die gesamte 
-      Länge der auseinander gelegten Klappe beträgt etwa 235 mm. Sie wird zur Fixierung bei etwa der Hälfte 
+      Länge der auseinander gelegten Klappe beträgt etwa 235  mm. Sie wird zur Fixierung bei etwa der Hälfte 
       der Länge geknickt und doppelt gelegt. Ober- und Untertritt sind am Ende mit einer 90 Grad gewinkelten, 
       spitzen Ausführung zu fertigen. Der Obertritt der Jackenschulterklappe ist mit einer Astraloneinlage oder 
     images:
@@ -2105,48 +2105,48 @@ pages:
       - page_41_image_2.png
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 43 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 43 
        
-      gleichwertiger Art zu versteifen. Im Bereich der Spitze sind Ober- und Untertritt mit einem Druckknopf, 
-      Metall, Durchmesser 15 mm, silber- oder goldfarbig, fixierbar auszustatten. Zum Tragen der Dienstgrad-
-      abzeichen auf vorheriger Uniform ist anstelle des Druckknopfes ein Durchlass von etwa 20 mm zu 
-      schaffen. Der Durchlass ist so zu gestalten, dass er sich nicht weiten oder reißen kann.  
+      gleichwertiger Art zu versteifen. Im Bereich der Spitze sind Ober - und Untertritt mit einem Druckknopf, 
+      Metall, Durchmesser 15  mm, silber- oder goldfarbig, fixierbar auszustatten. Zum Tragen der Dienstgrad-
+      abzeichen auf vorheriger Uniform ist anstelle des Druckknopfes ein Durchlass von etwa 20  mm zu 
+      schaffen. Der Durchlass ist so zu gestalten, dass er sich nicht weiten oder reißen kann.   
       Die Überziehschlaufen werden ohne Druckknopfnachbildung und ohne Spitze entsprechend der bild-
       lichen Darstellung getragen. Die zu stickenden roten, silber- oder goldfarbigen Elemente der Überzieh-
-      schlaufen werden mit metallisiertem Stickgarn ausgeführt. Die aufzubringenden Symbole (Eichenlaub 
+      schlaufen werden mit metallisiertem Stickgarn ausgeführt. Die aufzubringenden Symbole  (Eichenlaub 
       in kleiner und großer Form, Balken, Sterne und Umrandung) sind symmetrisch zur Längsachse anzu-
-      ordnen. Die Stärke der dargestellten Balken beträgt 4 mm. Sie haben eine Breite von 18 mm. Sterne 
-      haben einen Durchmesser von etwa 12 mm. Wenn für das Dienstgradabzeichen eine Umrandung vor-
-      gesehen ist, ist diese mindestens 1 mm, höchstens 2 mm stark. Bei der Aufbringung von mehreren 
-      Balken ist der Abstand zwischen den Balken von 4 mm einzuhalten.  
-      Sie sind als Rechteck mit einer Kantenlänge von 90 mm mal 55 mm auszugestalten. Als Stoffmate-
+      ordnen. Die Stärke der dargestellten Balken beträgt 4  mm. Sie haben eine Breite von 18  mm. Sterne 
+      haben einen Durchmesser von etwa 12  mm. Wenn für das Dienstgradabzeichen eine Umrandung vor-
+      gesehen ist, ist diese mindestens 1  mm, höchstens 2  mm stark. Bei der Aufbringung von mehreren 
+      Balken ist der Abstand zwischen den Balken von 4  mm einzuhalten.  
+      Sie sind als Rechteck mit einer Kantenlänge von 90  mm mal 55  mm auszugestalten. Als Stoffmate-
       rial ist dunkelblaues Baumwollmischgewebe in Anlehnung an die Jacken und Hosen zu nutzen. Die 
-      Umrandung des abgebildeten Dienstgrades erfolgt in rotem, silber- oder goldfarbigem Stickgarn als 
-      Rechteck parallel zu den Außenkanten.  
+      Umrandung des abgebildeten Dienstgrades erfolgt in rotem, silber - oder goldfarbigem Stickgarn als 
+      Rechteck parallel zu den Außenkanten.   
       Zur Befestigung von Überziehschlaufen auf Kleidungsstücken mit Gewebetunnel sind Schulteradap-
-      ter in gleicher Farbe wie das Kleidungsstück zulässig. Die Breite des Adapters soll 40 mm nicht über-
-      schreiten. Die gesamte Länge des auseinandergelegten Adapters ist etwa 230 mm. Die Ausführung 
-      kann mit Druckknopf (15 mm) oder Knopf (15 mm) mit Durchlass erfolgen.  
+      ter in gleicher Farbe wie das Kleidungsstück zulässig. Die Breite des Adapters soll 40  mm nicht über-
+      schreiten. Die gesamte Länge des auseinandergelegten Adapters i st etwa 230  mm. Die Ausführung 
+      kann mit Druckknopf (15  mm) oder Knopf (15  mm) mit Durchlass erfolgen.  
       Teil A: 
       I. Dienstgradabzeichen der Beamtinnen und Beamten des Feuerwehrdienstes  
       im zweiten Einstiegsamt der Laufbahngruppe 1  
       Beschreibung des 
       Amtsbezeichnung 
-      Nr. Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Nr.  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       mit Zusatz 
       chens 
-      1. Brandmeister- Schulterklappe 
-      anwärterin oder oder 
-      Brandmeisteran-Überziehschlaufe 
-      wärter mit stilisiertem 
+      1.  Brandmeister-  Schulterklappe 
+      anwärterin oder  oder 
+      Brandmeisteran- Überziehschlaufe 
+      wärter   mit stilisiertem 
       Eichenlaub in 
       kleiner Form, 
       silberfarbig, ein 
       silberfarbiger 
-      Balken   
-      2. Brandmeisterin wie Nummer 1  
-      oder  dieses  
-      Brandmeister Einstiegsamtes 
+      Balken    
+      2.  Brandmeisterin  wie Nummer 1  
+      oder   dieses  
+      Brandmeister  Einstiegsamtes 
       und dieser Lauf-
       bahngruppe, 
       jedoch mit zwei 
@@ -2158,47 +2158,47 @@ pages:
       - page_42_image_1.png
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 44 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 44 
        
-      3. Oberbrand- wie Nummer 1  
-      meisterin  dieses  
-      oder  Einstiegsamtes 
-      Oberbrandmeister und dieser Lauf-
+      3.  Oberbrand-  wie Nummer 1  
+      meisterin   dieses  
+      oder   Einstiegsamtes 
+      Oberbrandmeister  und dieser Lauf-
       bahngruppe, 
       jedoch mit drei 
       silberfarbigen 
       Balken 
        
-      4. Hauptbrand- wie Nummer 1  
-      meisterin  dieses  
-      oder Hauptbrand-Einstiegsamtes 
-      meister und dieser Lauf-
+      4.  Hauptbrand-  wie Nummer 1  
+      meisterin   dieses  
+      oder Hauptbrand- Einstiegsamtes 
+      meister  und dieser Lauf-
       bahngruppe, 
       jedoch mit vier 
       silberfarbigen 
       Balken 
        
-      5. Hauptbrand- wie Nummer 1  
-      meisterin mit Zu-dieses  
-      lage  Einstiegsamtes 
-      oder  und dieser Lauf-
-      Hauptbrand- bahngruppe, 
-      meister mit Zu-jedoch mit vier 
-      lage silberfarbigen 
+      5.  Hauptbrand-  wie Nummer 1  
+      meisterin mit Zu- dieses  
+      lage   Einstiegsamtes 
+      oder   und dieser Lauf-
+      Hauptbrand-   bahngruppe, 
+      meister mit Zu- jedoch mit vier 
+      lage  silberfarbigen 
       Balken und einem 
-      silberfarbigen  
+      silberfarbigen   
       Stern 
       II. Dienstgradabzeichen der Beamtinnen und Beamten des Feuerwehrdienstes 
-      im ersten Einstiegsamt der Laufbahngruppe 2 
-      Amtsbezeichnung Beschreibung des 
-      Nr. Bildliche Darstellung am Beispiel der Schulterklappe 
-      mit Zusatz Dienstgradabzeichens 
-      1. Brandober- Schulterklappe oder 
-      inspektor- Überziehschlaufe 
-      anwärterin  mit stilisiertem  
-      oder  Eichenlaub in gro-
-      Brandober- ßer Form, silberfar-
-      inspektoranwärter big, ein silberfarbi-
+      im ersten Einstiegsamt der Laufbahngruppe 2  
+      Amtsbezeichnung  Beschreibung des 
+      Nr.  Bildliche Darstellung am Beispiel der Schulterklappe  
+      mit Zusatz  Dienstgradabzeichens 
+      1.  Brandober-  Schulterklappe oder 
+      inspektor-  Überziehschlaufe 
+      anwärterin    mit stilisiertem  
+      oder   Eichenlaub in gro-
+      Brandober-  ßer Form, silberfar-
+      inspektoranwärter   big, ein silberfarbi-
       ger Balken 
        
     images:
@@ -2208,41 +2208,41 @@ pages:
       - page_43_image_3.png
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 45 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 45 
        
-      2. Brandinspektorin wie Nummer 1  
-      oder  dieses Einstiegsam-
-      Brandinspektor tes und dieser Lauf-
+      2.  Brandinspektorin  wie Nummer 1  
+      oder   dieses Einstiegsam-
+      Brandinspektor  tes und dieser Lauf-
       bahngruppe, jedoch 
       mit zwei silberfarbi-
       gen Balken 
        
-      3. Brandober- wie Nummer 1  
-      inspektorin  dieses Einstiegsam-
-      oder  tes und dieser Lauf-
-      Brandober- bahngruppe, jedoch 
-      inspektor mit drei silberfarbi-
+      3.  Brandober-  wie Nummer 1  
+      inspektorin   dieses Einstiegsam-
+      oder   tes und dieser Lauf-
+      Brandober-  bahngruppe, jedoch 
+      inspektor  mit drei silberfarbi-
       gen Balken 
        
-      4. Brandamtfrau wie Nummer 1  
-      oder Brandamt-dieses Einstiegsam-
-      mann tes und dieser Lauf-
+      4.  Brandamtfrau  wie Nummer 1  
+      oder Brandamt- dieses Einstiegsam-
+      mann  tes und dieser Lauf-
       bahngruppe, jedoch 
       mit vier 
       silberfarbigen 
       Balken 
        
-      5. Brandamtsrätin wie Nummer 1  
-      oder Brandamts-dieses Einstiegsam-
-      rat tes und dieser Lauf-
+      5.  Brandamtsrätin  wie Nummer 1  
+      oder Brandamts- dieses Einstiegsam-
+      rat  tes und dieser Lauf-
       bahngruppe, jedoch 
       mit vier 
       silberfarbigen 
       Balken und einem 
       silberfarbigen Stern 
        
-      6. Brandrätin oder Schulterklappe oder 
-      Brandrat Überziehschlaufe 
+      6.  Brandrätin oder  Schulterklappe oder 
+      Brandrat  Über ziehschlaufe 
       mit stilisiertem Ei-
       (als Beförde-
       chenlaub in großer 
@@ -2263,43 +2263,43 @@ pages:
       - page_44_image_4.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 46 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 46 
        
       III. Dienstgradabzeichen der Beamtinnen und Beamten des Feuerwehrdienstes  
-      im zweiten Einstiegsamt der Laufbahngruppe 2 
+      im zweiten Einstiegsamt der Laufbahngruppe 2  
       Beschreibung des 
       Amtsbezeichnung 
-      Nr. Dienstgradabzei-Bildliche Darstellung am Beispiel der Schulterklappe 
+      Nr.  Dienstgradabzei- Bildliche Darstellung am Beispiel der Schulterklappe 
       mit Zusatz 
       chens 
-      1. Brandreferendarin Schulterklappe 
-      oder  oder Überzieh-
-      Brandreferendar schlaufe mit  
+      1.  Brandreferendarin  Schulterklappe 
+      oder   oder Überzieh-
+      Brandreferendar  schlaufe mit  
       stilisiertem Eichen-
       laub in großer 
       Form, goldfarbig, 
       ein goldfarbiger 
       Balken 
        
-      2. Brandrätin oder wie Nummer 1  
-      Brandrat dieses  
+      2.  Brandrätin oder  wie Nummer 1  
+      Brandrat  dieses  
       Einstiegsamtes 
       und dieser Lauf-
       bahngruppe, je-
       doch mit zwei gold-
       farbigen Balken 
        
-      3. Brandoberrätin wie Nummer 1  
-      oder Brandoberrat dieses  
+      3.  Brandoberrätin  wie Nummer 1  
+      oder Brandoberrat  dieses  
       Einstiegsamtes 
       und dieser Lauf-
       bahngruppe, je-
       doch mit drei gold-
       farbigen Balken 
        
-      4. Branddirektorin wie Nummer 1  
-      oder  dieses  
-      Branddirektor Einstiegsamtes 
+      4.  Branddirektorin  wie Nummer 1  
+      oder   dieses  
+      Branddirektor  Einstiegsamtes 
       und dieser Lauf-
       bahngruppe, je-
       doch mit vier gold-
@@ -2312,50 +2312,50 @@ pages:
       - page_45_image_3.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 47 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 47 
        
-      5. Leitende Brand- wie Nummer 1  
-      direktorin oder dieses 
-      Leitender Brand-Einstiegsamtes 
-      direktor;  und dieser Lauf-
-      Ministerialrätin bahngruppe, je-
-      oder Ministerialrat doch mit vier gold-
-      im Ministerium für farbigen Balken 
-      Inneres und Sport  und einem 
-      goldfarbigen Stern  
-      6. Direktorin der wie Nummer 1  
-      Feuerwehr oder dieses  
-      Direktor der Feu-Einstiegsamtes 
-      erwehr;  und dieser Lauf-
-      Ministerialrätin bahngruppe, je-
-      oder Ministerialrat doch mit vier gold-
-      im Ministerium für farbigen Balken 
-      Inneres und Sport  und zwei 
-      goldfarbigen  
+      5.  Leitende Brand-  wie Nummer 1  
+      direktorin  oder  dieses 
+      Leitender Brand- Einstiegsamtes 
+      direktor;   und dieser Lauf-
+      Ministerialrätin  bahngruppe, je-
+      oder Ministerialrat  doch mit vier gold-
+      im Ministerium  für  farbigen Balken 
+      Inneres und Sport   und einem 
+      goldfarbigen Stern   
+      6.  Direktorin der  wie Nummer 1  
+      Feuerwehr oder  dieses  
+      Direktor der Feu- Einstiegsamtes 
+      erwehr;   und dieser Lauf-
+      Ministerialrätin  bahngruppe, je-
+      oder Ministerialrat  doch mit vier gold-
+      im Ministerium für  farbigen Balken 
+      Inneres und Sport   und zwei 
+      goldfarbigen   
       Sternen 
-      7. Präsidentin oder wie Nummer 1  
-      Präsident des dieses  
-      Niedersächsi-Einstiegsamtes 
-      schen Landes- und dieser Lauf-
-      amtes für Brand- bahngruppe, je-
-      und Katastro-doch mit vier gold-
-      phenschutz  farbigen Balken 
+      7.  Präsidentin oder  wie Nummer 1  
+      Präsident des  dieses  
+      Niedersächsi- Einstiegsamtes 
+      schen Landes-  und dieser Lauf-
+      amtes für Brand-   bahngruppe, je-
+      und Katastro- doch mit vier gold-
+      phenschutz   farbigen Balken 
       und zwei 
       goldfarbigen 
       Sternen, eine 
-      schmale goldene  
+      schmale goldene   
       Linie als 
       Umrandung 
-      8. Landesbrand- wie Nummer 1  
-      direktorin oder dieses  
-      Landesbrand- Einstiegsamtes 
-      direktor  und dieser Lauf-
+      8.  Landesbrand-  wie Nummer 1  
+      direktorin oder  dieses  
+      Landesbrand-   Einstiegsamtes 
+      direktor   und dieser Lauf-
       bahngruppe, je-
       doch mit vier gold-
       farbigen Balken 
       und drei goldfarbi-
       gen Sternen, eine 
-      schmale goldene  
+      schmale goldene   
       Linie als 
       Umrandung 
     images:
@@ -2365,45 +2365,45 @@ pages:
       - page_46_image_3.jpg
   -
     content: |-
-      Nds. GVBl. 2025 Nr. 25 vom 10. April 2025  Seite 48 
+      Nds. GVBl. 2025  Nr. 25 vom 10. April 2025   Seite 48 
        
       Teil B:  
       Dienstgradabzeichen neuer Art für Amtsbezeichnungen, die nicht mehr vergeben werden 
-      Amtsbezeichnung Beschreibung des 
-      Nr. Bildliche Darstellung am Beispiel der Schulterklappe 
-      mit Zusatz Dienstgradabzeichens 
-      1. Brandoberamts-Schulterklappe oder 
-      rätin oder Brand-Überziehschlaufe 
-      oberamtsrat mit stilisiertem  
+      Amtsbezeichnung  Beschreibung des 
+      Nr.  Bildliche Darstellung am Beispiel der Schulterklappe 
+      mit Zusatz  Dienstgradabzeichens 
+      1.  Brandoberamts- Schulterklappe oder 
+      rätin oder Brand- Überziehschlaufe 
+      oberamtsrat  mit stilisiertem  
       Eichenlaub in gro-
       ßer Form, silberfar-
       big, vier 
       silberfarbige Balken 
       und zwei 
-      silberfarbige Sterne  
-      2. Brandoberamts-wie Nummer 1 der 
-      rätin mit Zulage Anlage 9 Teil B, je-
-      oder Brandober-doch mit drei silber-
-      amtsrat mit  farbigen Sternen 
+      silberfarbige Sterne   
+      2.  Brandoberamts- wie Nummer 1 der 
+      rätin mit Zulage  Anlage 9 Teil B, je-
+      oder Brandober- doch mit drei silber-
+      amtsrat mit   farbigen Sternen 
       Zulage 
       . 
-      20. Es wird die folgende Anlage 10 angefügt: 
+      20.  Es wird die folgende Anlage 10 angefügt:  
       Anlage 10 
       (zu § 14 Satz 2) 
       Kennzeichnung der Feuerwehrhelme der Beamtinnen und Beamten des Feuerwehrdienstes  
-      während des Einsatzdienstes in der Freiwilligen Feuerwehr oder Pflichtfeuerwehr  
-      Kennzeichnung Voraussetzung 
-      ein roter Strei-Beamtin oder Beamter des Feuerwehrdienstes mit Laufbahnbefähigung für das 
-      fen auf beiden zweite Einstiegsamt der Laufbahngruppe 1 nach dem Zweiten Teil der Verordnung 
-      Helmseiten über die Ausbildung und Prüfung für die Laufbahnen der Fachrichtung Feuerwehr 
-      vom 26. Januar 2012 (Nds. GVBl. S. 24, 72), zuletzt geändert durch Verordnung 
-      vom 7. Juli 2022 (Nds. GVBl. S. 463), oder mit einer gleichwertigen Ausbildung 
-      ein roter Ring Beamtin oder Beamter des Feuerwehrdienstes mit Laufbahnbefähigung für das 
-      erste Einstiegsamt der Laufbahngruppe 2.  
+      während des Einsatzdienstes in der Freiwilligen Feuerwehr oder Pflichtfeuerwehr   
+      Kennzeichnung  Voraussetzung 
+      ein roter Strei- Beamtin oder Beamter des Feuerwehrdienstes mit Laufbahnbefähigung für das 
+      fen auf beiden  zweite Einstiegsamt der Laufbahngruppe 1 nach dem Zweiten Teil der Verordnung 
+      Helmseiten  über die Ausbildung und Prüfung für die Laufbahnen der Fachrichtung Feuerwehr 
+      vom 26. Januar 2012 (Nds. GVBl. S. 24, 72) , zuletzt geändert durch Verordnung 
+      vom 7. Juli 2022 (Nds. GVBl. S. 463),  oder mit einer gleichwertigen Ausbildung 
+      ein roter Ring  Beamtin oder Beamter des Feuerwehrdienstes mit Laufbahnbefähigung für das 
+      erste Einstiegsamt der Laufbahngruppe 2.   
       Artikel 2 
-      Diese Verordnung tritt am 11. April 2025 in Kraft. 
-      Hannover, den 8. April 2025 
-      Niedersächsisches Ministerium 
+      Diese Verordnung tritt am 11. April 2025  in Kraft. 
+      Hannover, den  8. April 2025 
+      Niedersächsisches Ministerium  
       für Inneres und Sport 
       Behrens 
       Ministerin 

--- a/tests/Samples/files/issue-255/contents.yml
+++ b/tests/Samples/files/issue-255/contents.yml
@@ -22,8 +22,8 @@ pages:
       „Zusammenhalt stärken – Menschen verbinden“ 
       ESF Plus-Förderperiode 2021 bis 2027 
       Vom 17. September 2025 
-      1 Förderziel und Zuwendungszweck 
-      1.1 Ziel der Förderung 
+      1  Förderziel und Zuwendungszweck 
+      1.1  Ziel der Förderung 
       In Deutschland fühlen sich Millionen Menschen einsam. Einsamkeit kann jede und jeden treffen. 
       Das Bundesministerium für Bildung, Familie, Senioren, Frauen und Jugend (BMBFSFJ) setzt sich deshalb dafür ein, 
       dieser gesamtgesellschaftlichen Herausforderung wirksam zu begegnen. 
@@ -62,7 +62,7 @@ pages:
       Kommunale Strukturen können in unterschiedlicher Form begleitend in diesen individuellen Lebensphasen agieren, 
       womit Zugänge zu Individuen entstehen. 
       Zu nennen sind beispielsweise  
-      –Berufsberatung am Übergang von einer Ausbildung oder einem Studium zu einem ersten Berufseinstieg bezie-
+      – Berufsberatung am Übergang von einer Ausbildung oder einem Studium zu einem ersten Berufseinstieg bezie-
       hungsweise die Aufgabe beruflicher Etablierung,   
       – Ehe- und Familienberatung am Übergang von Partnerschaft zu Elternschaft beziehungsweise Familiengründung,   
       – spezialisierte Beratung und Verweisberatung in den Fällen von Insolvenz, Trauer und so weiter,   
@@ -101,7 +101,7 @@ pages:
       in welchen Menschen eher einsam werden können (kommunale Aktionspläne, bereichsübergreifende Arbeits-
       gruppen und Öffentlichkeitsarbeit, Vernetzung in die Zivilgesellschaft)   
       – Verbesserung der sozialen Teilhabe der Zielgruppe  
-      –Schaffung eines konkreten Mehrwerts für städtische Quartiere beziehungsweise den ländlichen Raum, der Ein-
+      – Schaffung eines konkreten Mehrwerts für städtische Quartiere beziehungsweise den ländlichen Raum, der Ein-
       samkeit vorbeugt und lindert (zum Beispiel Rentenberatung, Verbesserungen im Wohnumfeld und im Zusam-
       menleben der Bewohnerinnen und Bewohner, Schaffung zusätzlicher gemeinwohlorientierter Angebote)   
       – Sensibilisierung und Weiterentwicklung der kommunalen Strukturen zum Thema Einsamkeit und soziale 
@@ -109,12 +109,12 @@ pages:
       B. Erkenntnisziele:   
       – Erkenntnisgewinn zur Optimierung von Maßnahmen zur Vorbeugung und Linderung von Einsamkeit und sozialer 
       Isolation  
-      –Erkenntnisgewinn über Maßnahmen zur Unterstützung einer sozialen, nachhaltigen Stadt- und Ortsteilentwick-
+      – Erkenntnisgewinn über Maßnahmen zur Unterstützung einer sozialen, nachhaltigen Stadt- und Ortsteilentwick-
       lung beziehungsweise zur Unterstützung der Entwicklung des ländlichen Raums durch Erprobung verschiedener 
       Maßnahmen, um örtliche Strukturen auszubauen und zu stärken   
       – Erkenntnisgewinn zu Gelingensfaktoren zur strukturellen Entwicklung von Beratungsstrukturen zum Thema 
       Einsamkeit und soziale Isolation 
-      1.2 Rechtsgrundlagen 
+      1.2  Rechtsgrundlagen 
       Die Förderung des Programms aus dem Europäischen Sozialfonds Plus (ESF Plus) erfolgt auf der Grundlage der 
       Verordnung (EU) 2021/1057 des Europäischen Parlaments und des Rates vom 24. Juni 2021 (ESF Plus-Verordnung) 
       und der Verordnung (EU) 2021/1060 des Europäischen Parlaments und des Rates vom 24. Juni 2021 (Allgemeine 
@@ -143,7 +143,7 @@ pages:
       Die Bewilligungsbehörde entscheidet aufgrund der eingereichten Unterlagen im Rahmen ihres pflichtgemäßen Ermes-
       sens und der verfügbaren Haushaltsmittel über die Förderung der Projekte. Ein Rechtsanspruch auf die Förderung 
       besteht nicht. 
-      2 Gegenstand der Förderung 
+      2  Gegenstand der Förderung 
       Gefördert werden Vorhaben, die Strukturen zur Vorbeugung und Linderung von Einsamkeit und sozialer Isolation bei 
       Menschen zwischen 28 und 59 Jahren schaffen oder verbessern. Die Vorhaben müssen Maßnahmen der folgenden 
       Ziele A und B in einem Projekt umsetzen:   
@@ -153,12 +153,12 @@ pages:
       – Auf- und Ausbau von übergreifenden Arbeitskreisen   
       – Vernetzung zwischen kommunalen und zivilgesellschaftlichen Strukturen   
       – Identifikation und Kooperation mit den für das Thema Einsamkeit wichtigen Stellen  
-      –abgestimmte Öffentlichkeitsarbeit zur Bekanntmachung der Aktionen beziehungsweise Angebote gegen Ein-
+      – abgestimmte Öffentlichkeitsarbeit zur Bekanntmachung der Aktionen beziehungsweise Angebote gegen Ein-
       samkeit   
       – Veranstaltungen zur Sensibilisierung von Mitarbeitenden in kommunalen Strukturen zum Thema Einsamkeit   
       – Erarbeitung digitaler Angebote zur Vorbeugung und Linderung von Einsamkeit   
       B. Verbesserung der sozialen Teilhabe und Arbeitsmarktchancen der Zielgruppen, wie zum Beispiel:  
-      –Aufbau von kommunalen und zivilgesellschaftlichen Beratungsstellen und/oder Etablierung des Themas Ein-
+      – Aufbau von kommunalen und zivilgesellschaftlichen Beratungsstellen und/oder Etablierung des Themas Ein-
       samkeit in vorhandenen Beratungsstrukturen   
       – Ausbau von Angeboten zur Verbesserung der finanziellen Situation der Zielgruppe   
       – Veranstaltungen und weitere Formate zur Sensibilisierung zum Thema Einsamkeit   
@@ -172,13 +172,13 @@ pages:
       Kooperationen mit anderen Gebietskörperschaften, Behörden, gemeinnützigen Trägern mit Sitz und Arbeitsstätte in 
       Deutschland, Unternehmen oder Forschungsinstituten und so weiter sind möglich. 
       Die Teilnahme der Zielgruppe an den Angeboten ist grundsätzlich freiwillig. 
-      3 Zuwendungsempfänger 
-      3.1 Antragsberechtigung 
+      3  Zuwendungsempfänger 
+      3.1  Antragsberechtigung 
       Gemeinden, Landkreise, kreisfreie Städte und Bezirke in einem Stadtstaat (= Gebietskörperschaft) sind antrags-
       berechtigt. 
       Antragstellende müssen ihre fachlich-inhaltliche sowie administrative Befähigung zur Durchführung eines Vorhabens 
       darlegen und eine zweckentsprechende Verwendung der Zuwendung sicherstellen. 
-      3.2 Weiterleitung der Zuwendung (Teilvorhabenpartner) 
+      3.2  Weiterleitung der Zuwendung (Teilvorhabenpartner) 
       Ein Projekt kann auch durch Teilvorhabenpartner durchgeführt werden. 
       Als Teilvorhabenpartner kommen Gebietskörperschaften, Behörden, gemeinnützige Träger mit Sitz und Arbeitsstätte 
       in Deutschland, Unternehmen oder Forschungsinstitute und so weiter in Betracht. 
@@ -195,45 +195,45 @@ pages:
       Veröffentlicht am Mittwoch, 1. Oktober 2025
       BAnz AT 01.10.2025 B1
       Seite 4 von 8
-      3.3 Nachweis der Kooperation 
+      3.3  Nachweis der Kooperation 
       Soweit ein Projekt im Verbund mit weiteren Gebietskörperschaften oder anderen Teilvorhabenpartnern durchgeführt 
       wird, ist eine Kooperationsvereinbarung vorzulegen. In der Kooperationsvereinbarung müssen die vereinbarten 
       Förderziele und die Verteilung innerhalb der Kooperation beschrieben werden. 
-      4 Besondere Zuwendungsvoraussetzungen 
+      4  Besondere Zuwendungsvoraussetzungen 
       Die Erfüllung der nachfolgend genannten Zuwendungsvoraussetzungen ist bei der Antragstellung nachzuweisen. 
       Spätester Vorhabenbeginn ist der 1. Juli 2027. 
-      4.1 Gesamtfinanzierung 
+      4.1  Gesamtfinanzierung 
       Die Gesamtfinanzierung des Vorhabens muss sichergestellt sein. Voraussetzung für die Projektförderung ist der voll-
       ständige Nachweis des vom Antragsteller beizubringenden Eigenanteils für das Vorhaben. Eine Absichtserklärung 
       reicht zunächst in der Interessenbekundung aus. Die Kofinanzierungszusage ist spätestens bei der Antragstellung 
       vorzulegen. 
-      4.2 Ausschluss der Förderung bei Pflichtaufgaben 
+      4.2  Ausschluss der Förderung bei Pflichtaufgaben 
       Es können keine Vorhaben gefördert werden, die zu den Pflichtaufgaben eines Antragstellenden gehören beziehungs-
       weise für die es bereits gesetzliche oder sonstige öffentlich-rechtliche Finanzierungsregelungen gibt. 
-      4.3 Ausschluss der Förderung bei Insolvenzverfahren 
+      4.3  Ausschluss der Förderung bei Insolvenzverfahren 
       Antragstellenden Teilvorhabenpartnern, über deren Vermögen ein Insolvenzverfahren beantragt oder eröffnet worden 
       ist, wird keine Förderung gewährt. Dasselbe gilt für Antragstellende, die zur Abgabe einer Vermögensauskunft nach 
       § 802c der Zivilprozessordnung oder § 284 der Abgabenordnung verpflichtet sind oder bei denen diese abgenommen 
       wurde. 
-      4.4 Keine rückwirkende Förderung 
+      4.4  Keine rückwirkende Förderung 
       Eine rückwirkende Förderung ist nicht möglich. Zuwendungen können nur für solche Vorhaben bewilligt werden, die 
       noch nicht begonnen wurden. 
-      4.5 Reduzierung der bewilligten Mittel 
+      4.5  Reduzierung der bewilligten Mittel 
       Sofern die mit dem Zuwendungsbescheid festgelegte Höhe des mindestens zu erbringenden Eigenanteils – entgegen 
       der mit der Antragstellung vorgelegten Kofinanzierungszusage – im Förderzeitraum nicht erbracht wird, führt dies 
       mindestens zur anteiligen Reduzierung der bewilligten Mittel. Kann aufgrund des fehlenden Eigenanteils die Gesamt-
       finanzierung nicht erreicht werden, kann der Widerruf des Zuwendungsbescheids und damit ein Ausscheiden aus dem 
       Programm und eine Rückforderung der gewährten Zuwendung erfolgen. 
-      4.6 Einsatz der Mittel 
+      4.6  Einsatz der Mittel 
       Der Zuwendungsempfänger ist verpflichtet, die Fördermittel sparsam und wirtschaftlich sowie zweckentsprechend 
       einzusetzen. 
-      4.7 Überwachung der Finanzierung 
+      4.7  Überwachung der Finanzierung 
       Die Zuwendungsempfänger sind verpflichtet, die Finanzierung ihres Projekts zu überwachen. Defizite in den Einnah-
       men sind vom Zuwendungsempfänger auszugleichen. 
-      4.8 Dauer der Bewilligung 
+      4.8  Dauer der Bewilligung 
       Die Zuwendung wird grundsätzlich für den Zeitraum vom 1. September 2024 bis zum 31. Dezember 2028 gewährt. 
-      5 Art und Umfang, Höhe der Zuwendung 
-      5.1 Art der Förderung, Fördersätze, Kofinanzierung und Eigenanteil 
+      5  Art und Umfang, Höhe der Zuwendung 
+      5.1  Art der Förderung, Fördersätze, Kofinanzierung und Eigenanteil 
       Die Zuwendung an die Gebietskörperschaft wird im Wege der Projektförderung als Anteilsfinanzierung in Form eines 
       nicht rückzahlbaren Zuschusses gewährt. 
       Dabei kommen die für die Zielgebiete des ESF Plus geltenden Interventionssätze zur Anwendung. Die Fördersätze 
@@ -266,24 +266,24 @@ pages:
       empfänger im Finanzierungsplan darzulegen. 
       Eine zielgebietsübergreifende Förderung ist ausgeschlossen. Projekte müssen entweder in der stärker entwickelten 
       Region oder in der Übergangsregion durchgeführt werden. 
-      5.2 Zuwendungsfähige Ausgaben 
-      5.2.1 Direkte Personalausgaben 
+      5.2  Zuwendungsfähige Ausgaben 
+      5.2.1  Direkte Personalausgaben 
       Direkte Personalausgaben sowie Ausgaben ohne Geldfluss (Personalgestellung) der Stufen 9b bis 11 TVöD werden 
       auf Grundlage von Artikel 53 Absatz 1 Buchstabe b der Verordnung (EU) Nr. 2021/1060 als Kosten je Einheit gewährt. 
       Stellenanteile von weniger als 25 Prozent einer Vollzeitstelle sind grundsätzlich nicht zuwendungsfähig. 
-      5.2.1.1 Einrichtung einer Personalstelle mit koordinierendem Anteil 
+      5.2.1.1  Einrichtung einer Personalstelle mit koordinierendem Anteil 
       Ein Zuwendungsempfänger ist verpflichtet, eine Personalstelle als Projektkoordination einzurichten, welche als Pro-
       jektleitung und zentrale Ansprechperson fungiert. 
       Die projektkoordinierende Personalstelle gilt als zentrale Ansprechperson gegenüber dem Bundesamt für Familie 
       und zivilgesellschaftliche Aufgaben (BAFzA). Auf Grundlage der vorliegenden Angebotsstruktur arbeitet die Projekt-
       koordination an der passgenauen Etablierung der Angebote unter den Einzelzielen der Buchstaben A und B. 
-      5.2.1.2 Fachliche Qualifikation des Projektpersonals 
+      5.2.1.2  Fachliche Qualifikation des Projektpersonals 
       Das Projektpersonal, welches zur Erreichung der Einzelziele der Buchstaben A und B eingesetzt wird, muss mindes-
       tens über einen Fachhochschul- oder Hochschulabschluss (Bachelor, Diplomgrad mit dem Zusatz „Fachhochschule“) 
       oder einen gleichwertigen Abschlussgrad verfügen. Bei der Antragstellung ist ein entsprechender Nachweis über 
-      ein verwaltungsrechtliches, sozial-, gesundheits-, politik-, geisteswissenschaftliches oder juristisches Studium 
+      ein  verwaltungsrechtliches,  sozial-,  gesundheits-,  politik-,  geisteswissenschaftliches  oder  juristisches  Studium 
       einzureichen. 
-      5.2.2 Honorare 
+      5.2.2  Honorare 
       Honorare werden auf Grundlage von Artikel 53 Absatz 1 Buchstabe a der Verordnung (EU) Nr. 2021/1060 nach 
       tatsächlich angefallener Höhe abgerechnet. Zuwendungsfähig ist dabei nur die Honorarvergütung, die als Gegen-
       leistung für die Tätigkeit gezahlt wird. Honorare an Vorstandsmitglieder, Geschäftsführungen und hauptamtliche 
@@ -293,21 +293,21 @@ pages:
       können nicht direkt abgerechnet werden. 
       Honorarkräfte können zur Erledigung von Teilaufgaben im Projekt eingesetzt werden. Honorare dürfen nicht mehr als 
       25 Prozent der Ausgaben der Antragstellenden für eigenes Personal im Projekt ausmachen. 
-      5.3 Restkosten 
+      5.3  Restkosten 
       Alle weiteren zuwendungsfähigen Ausgaben werden als Pauschalsatz in Höhe von 20 Prozent der direkten förder-
       fähigen Personalausgaben gemäß Artikel 56 Absatz 1 der Verordnung (EU) 2021/1060 abgedeckt. Als direkte förder-
       fähige Personalausgaben gelten für diese Berechnung neben den direkten Personalausgaben (Nummer 5.2.1) auch 
       die Honorare (Nummer 5.2.2). 
       Indirekte Projektausgaben werden über diesen Pauschalsatz abgedeckt und können nicht als Eigenbeteiligung an-
       erkannt werden. 
-      5.4 Weitere Verfahrensregelungen 
+      5.4  Weitere Verfahrensregelungen 
       Die Anwendung der Restkostenpauschale entbindet nicht von der Einhaltung anderer europäischer oder nationaler 
       Rechtsvorschriften, insbesondere des öffentlichen Vergaberechtes. 
       Über die genannten Ausgabenpositionen hinaus sind keine weiteren Ausgaben abrechenbar. 
       Einzelheiten hierzu finden sich in den Fördergrundsätzen für die Bewilligung von Zuwendungen aus dem ESF Plus in 
       der Förderperiode 2021 bis 2027 (Fördergrundsätze). 
-      6 Sonstige Zuwendungsbestimmungen 
-      6.1 Bereichsübergreifende Grundsätze (Querschnittsziele) und ökologische Nachhaltigkeit 
+      6  Sonstige Zuwendungsbestimmungen 
+      6.1  Bereichsübergreifende Grundsätze (Querschnittsziele) und ökologische Nachhaltigkeit 
       In allen Phasen der Programmplanung und -umsetzung sind gemäß Artikel 9 der Verordnung (EU) 2021/1060 in Ver-
       bindung mit Artikel 6 der Verordnung (EU) 2021/1057 die bereichsübergreifenden Grundsätze Gleichstellung der 
       Geschlechter und der Antidiskriminierung unter Hinzunahme des Ziels der ökologischen Nachhaltigkeit integriert 
@@ -328,7 +328,7 @@ pages:
       Absatz 1 der Verordnung (EU) 2021/1057 sowie Artikel 9 Absatz 1 der Verordnung (EU) 2021/1060 darf bei der 
       Programmplanung und -umsetzung die Charta der Grundrechte der Europäischen Union und das damit verbundene 
       Ziel, die fundamentalen Rechte der EU-Bürgerinnen und -Bürger zu sichern, nicht verletzt werden. 
-      6.2 Mitwirkung/Datenspeicherung 
+      6.2  Mitwirkung/Datenspeicherung 
       Die Zuwendungsempfänger und gegebenenfalls beteiligte Stellen sind verpflichtet, im Rahmen der Finanzkontrolle 
       durch die in Nummer 7.6 genannten Stellen mitzuwirken und die erforderlichen Auskünfte zu erteilen. Mit dem Antrag 
       erklären sich die Antragstellenden damit einverstanden, die notwendigen Daten für die Projektbegleitung, Projekt-
@@ -337,7 +337,7 @@ pages:
       wurden, sind auf Anforderung der prüfenden Stelle in elektronischer Form zu übermitteln. Die Erfüllung der Berichts-
       pflichten und die Erhebung und Pflege der Daten sind Voraussetzung für den Abruf von Fördermitteln bei der Euro-
       päischen Kommission und deren Auszahlung. 
-      6.3 Monitoring und Evaluierung des Programms 
+      6.3  Monitoring und Evaluierung des Programms 
       Die Zuwendungsempfänger sind grundsätzlich verpflichtet, die gemeinsamen Output- und Ergebnisindikatoren für 
       ESF Plus-Interventionen gemäß Anhang I der Verordnung (EU) 2021/1057 als auch weitere programmrelevante Daten 
       zu erheben und dem Zuwendungsgeber zu vorgegebenen Zeitpunkten zu übermitteln. 
@@ -348,7 +348,7 @@ pages:
       beauftragten Stellen zusammenzuarbeiten. Insbesondere müssen sie die erforderlichen Projektdaten zur finanziellen 
       und materiellen Steuerung in das dafür eingerichtete IT-System regelmäßig eingeben. Die erhobenen Daten bilden die 
       Grundlage für die Berichtspflichten der ESF-Verwaltungsbehörde gegenüber der Europäischen Kommission. 
-      6.4 Transparenz der Förderung 
+      6.4  Transparenz der Förderung 
       Die Zuwendungsempfänger erklären sich damit einverstanden, dass unter anderem entsprechend Artikel 49 Absatz 3 
       der Allgemeinen Strukturfondsverordnung der Verordnung (EU) 2021/1060 Informationen öffentlich zugänglich (zum 
       Beispiel auf der Internetseite der ESF-Verwaltungsbehörde www.esf.de) sind, wie beispielsweise:   
@@ -378,48 +378,48 @@ pages:
       Veröffentlicht am Mittwoch, 1. Oktober 2025
       BAnz AT 01.10.2025 B1
       Seite 7 von 8
-      6.5 Kommunikation 
+      6.5  Kommunikation 
       Mit ihrem Antrag verpflichten sich die Antragstellenden dazu, den Anforderungen an die Informations- und Publizitäts-
       maßnahmen der Begünstigten im Hinblick auf Sichtbarkeit und Transparenz gemäß Artikel 46 Buchstabe a, Artikel 47 
       sowie Artikel 50 in Verbindung mit Anhang IX der Verordnung (EU) 2021/1060 zu entsprechen und auf eine Förderung 
       des Programms/Projekts durch den ESF Plus hinzuweisen. 
-      6.6 IT-System 
+      6.6  IT-System 
       Das gesamte ESF Plus-Zuwendungsverfahren wird elektronisch über das Projektverwaltungssystem Förderportal 
       Z-EU-S (https://foerderportal-zeus.de) abgewickelt. Auf der Eingangsseite des Förderportals sind Informationen zur 
       Registrierung für das Förderportal und ein Hilfe-Service abrufbar. 
       Die elektronische Form ist vorrangig zu nutzen. Für Details wird auf die Online-Hilfe von Z-EU-S verwiesen. Die posta-
       lische Nachreichung von Vorgängen ist nur im Ausnahmefall möglich, wenn eine elektronische Unterzeichnung nicht 
       möglich ist. 
-      7 Verfahren 
+      7  Verfahren 
       Das BMBFSFJ steuert das ESF Plus-Programm „Zusammenhalt stärken – Menschen verbinden“. 
       Mit der Koordinierung und fördertechnischen Umsetzung des ESF Plus-Programms hat das BMBFSFJ das BAFzA als 
       umsetzende Stelle beauftragt. 
       Die fachlich-inhaltliche Begleitung des Programms erfolgt ebenfalls durch das BAFzA. 
       Das Auswahlverfahren zur Ermittlung der Projekte erfolgt zweistufig. Es besteht aus einer Interessenbekundung und 
       einer Antragstellung. 
-      7.1 Interessenbekundung 
+      7.1  Interessenbekundung 
       In der ersten Stufe sind dem BAFzA Interessenbekundungen in elektronischer Form über Z-EU-S einzureichen. 
       Interessenbekundungen können jederzeit eingereicht werden, spätestens jedoch bis zum 31. Dezember 2026. 
       Aus der Vorlage einer Interessenbekundung kann kein Rechtsanspruch auf Aufforderung zur Antragstellung abgeleitet 
       werden. 
-      7.2 Antragstellung 
+      7.2  Antragstellung 
       Die für eine Förderung geeigneten Interessenbekundungen werden vom BMBFSFJ ausgewählt. Das Auswahlergebnis 
       wird den Teilnehmenden der Interessenbekundung elektronisch mitgeteilt. 
       Die aus den Interessenbekundungen ausgewählten Bewerber werden aufgefordert, einen förmlichen Förderantrag in 
       elektronischer Form über das Förderportal Z-EU-S (https://foerderportal-zeus.de) einzureichen. Die Einreichungsfrist 
       wird gesondert bekannt gegeben. 
-      7.3 Bewilligungsverfahren 
+      7.3  Bewilligungsverfahren 
       Dem BAFzA obliegt als Bewilligungsbehörde die Information und die fördertechnische Beratung der Antragstellenden, 
       die Prüfung der Förderanträge, die Bewilligung der Zuwendungen, die Auszahlung der Zuwendungen an die Zuwen-
       dungsempfänger sowie die Prüfung der Mittelverwendung (Verwendungsnachweisprüfung) und die Berichterstattung 
       gegenüber dem BMBFSFJ. 
       Die Fördergrundsätze für die Bewilligung von Zuwendungen aus dem ESF Plus in der Förderperiode 2021 bis 2027, 
-      abrufbar unter https://www.esf-regiestelle.de/esf-plus-2021-2027/zusammenhalt-staerken-menschen-verbinden/ 
+      abrufbar  unter  https://www.esf-regiestelle.de/esf-plus-2021-2027/zusammenhalt-staerken-menschen-verbinden/ 
       downloads/ oder www.esf.de, sind zu beachten. 
-      7.4 Anforderungs- und Auszahlungsverfahren 
+      7.4  Anforderungs- und Auszahlungsverfahren 
       Die Auszahlung erfolgt gemäß den Besonderen Nebenbestimmungen für ESF Plus-Zuwendungen (BNBEST-P/G-ESF- 
       Bund) grundsätzlich im Wege der Erstattung (Erstattungsverfahren). 
-      7.5 Zwischennachweis/Verwendungsnachweis 
+      7.5  Zwischennachweis/Verwendungsnachweis 
       Ausgaben, die auf Grundlage von Pauschalen gemäß Nummer 6.2.3 BNBest-P-ESF-Bund und Nummer 6.4.1 BNBest- 
       Gk-ESF-Bund abgerechnet werden, sind in einer Summe in der Belegliste aufzuführen. Der Zuwendungsempfänger 
       bestätigt, dass Ausgaben für den Zweck, für den die Pauschale gewährt wurde, tatsächlich angefallen sind und die 
@@ -427,7 +427,7 @@ pages:
       Soweit die Verwendungsbestätigung nicht erbracht wird, kann die Bewilligungsbehörde den Zuwendungsbescheid 
       nach § 49 Absatz 3 des Verwaltungsverfahrensgesetzes (VwVfG) mit Wirkung auch für die Vergangenheit ganz oder 
       teilweise widerrufen und die Zuwendung, auch wenn sie bereits verwendet worden ist, zurückfordern. 
-      7.6 Zu beachtende Vorschriften 
+      7.6  Zu beachtende Vorschriften 
       Für die Bewilligung, Auszahlung und Abrechnung der Zuwendung sowie für den Nachweis und die Prüfung der Ver-
       wendung und die gegebenenfalls erforderliche Aufhebung des Zuwendungsbescheids und die Rückforderung der 
       gewährten Zuwendung gelten die §§ 48 bis 49a VwVfG, die §§ 23, 44 BHO und die hierzu erlassenen Allgemeinen 
@@ -443,7 +443,7 @@ pages:
       Kommission, der Europäische Rechnungshof, das Europäische Amt für Betrugsbekämpfung (OLAF), die Europäische 
       Staatsanwaltschaft (EUStA), die ESF-Verwaltungsbehörde und die ESF-Prüfbehörde des Bundes sowie ihre zwi-
       schengeschalteten Stellen gemäß Nummer 7.4 BNBest-P-ESF-Bund, BNBest-Gk-ESF-Bund. 
-      8 Geltungsdauer 
+      8  Geltungsdauer 
       Diese Förderrichtlinie tritt am Tag der Veröffentlichung im Bundesanzeiger in Kraft und gilt bis zum 30. Juni 2029. 
       Gleichzeitig tritt die Förderrichtlinie „Zusammenhalt stärken – Menschen verbinden“ vom 10. November 2023 (BAnz 
       AT 24.11.2023 B2), die zuletzt durch die Bekanntmachung vom 31. Januar 2024 (BAnz AT 12.02.2024 B1) geändert 

--- a/tests/Samples/files/issue-291/contents.yml
+++ b/tests/Samples/files/issue-291/contents.yml
@@ -54,7 +54,7 @@ pages:
       Store NL. The applicants argue, inter alia, that Apple abuses its dominant position on the market for the distribution 
       of apps for its devices. That anticompetitive conduct has, in the applicants’ view, caused damage to the users of 
       Communications Directorate 
-      Press and Information Unit curia.europa.eu 
+      Press and Information Unit  curia.europa.eu 
     images:
       - page_0_image_0.png
   -
@@ -100,7 +100,7 @@ pages:
       1 Regulation (EU) No 1215/2012 of the European Parliament and of the Council of 12 December 2012 on jurisdiction and the recognition and 
       enforcement of judgments in civil and commercial matters. 
       Communications Directorate 
-      Press and Information Unit curia.europa.eu 
+      Press and Information Unit  curia.europa.eu 
     images:
       - page_1_image_0.png
       - page_1_image_1.png

--- a/tests/Samples/files/libreoffice-different-fonts-sizes/contents.yml
+++ b/tests/Samples/files/libreoffice-different-fonts-sizes/contents.yml
@@ -15,6 +15,6 @@ pages:
       Etiam vitae lectus sodales
       Vestibulum et augue vitae orci sagittis faucibus
       Donec risus risus
-      Lorem ipsum dolor sit ametviverra a aliquam elementum
+      Lorem ipsum dolor sit amet viverra a aliquam elementum
       ornare nec nisl
       consectetur adipiscing elit

--- a/tests/Samples/files/libreofficelorem-ipsum-with-titles-and-formatting/contents.yml
+++ b/tests/Samples/files/libreofficelorem-ipsum-with-titles-and-formatting/contents.yml
@@ -41,14 +41,14 @@ pages:
       ullam repellat et voluptatem delectus. Aut voluptatum pariatur Id molestias cum nobis molestias. Ut 
       velit distinctioEx consectetur eos debitis perspiciatis a minus commodi eos doloribus autem vel 
       accusamus sequi et quidem reiciendis. 
-      •Ut autem excepturi ut sequi laboriosam est quas debitis et placeat consequatur! 
-      •Qui autem voluptas eum deserunt dolor. 
-      •In nesciunt quia qui asperiores corrupti sed perspiciatis tempora id minus architecto! 
-      •Rem beatae quos aut fugit vero. 
-      •At adipisci enim id reiciendis officiis. 
+      • Ut autem excepturi ut sequi laboriosam est quas debitis et placeat consequatur! 
+      • Qui autem voluptas eum deserunt dolor. 
+      • In nesciunt quia qui asperiores corrupti sed perspiciatis tempora id minus architecto! 
+      • Rem beatae quos aut fugit vero. 
+      • At adipisci enim id reiciendis officiis. 
   -
     content: |-
-      •Sed sapiente quia qui sint dolorem vel impedit magni. 
+      • Sed sapiente quia qui sint dolorem vel impedit magni. 
       Et dicta voluptatem sit fugit saepevel nulla et debitis iure et ipsa voluptas? Est facere harum et 
       inventore eveniet Aut rerum est molestias quam qui perspiciatis magnam. 
       Qui eligendi saepe et neque autem A omnis et pariatur rerum est dolore rerum est facere quasi. Sit 
@@ -58,7 +58,7 @@ pages:
       In recusandae dolor id laudantium omnisaut velit aut perferendis omnis qui tenetur explicabo. Et 
       maxime assumenda et ipsam itaqueAut deleniti ut excepturi alias et fugit facere non modi laudantium. 
       Qui sapiente rerum non sunt ipsum Ad maxime est velit eligendi aut quaerat officia est architecto 
-      magnam? 
+      magnam ? 
       1.Et sequi ipsum et expedita ipsum eum dolore laborum. 
       2.Id enim unde eos commodi quidem et eius quaerat. 
       3.Est tempore veritatis sed aliquam Quis. 

--- a/tests/Samples/files/text-objects-across-multiple-streams/contents.yml
+++ b/tests/Samples/files/text-objects-across-multiple-streams/contents.yml
@@ -29,7 +29,7 @@ pages:
       accommodated. The user must first note that the MPK interface protocol is different from RS-422 or 
       RS-485.  
        
-      RS-422:  Two devices send data separately in each direction between them. Data in each 
+      RS-422:  Two devices send data separately in  each direction between them. Data in each 
       direction is carried over a balanced pair of wires. Each of the two devices is always 
       transmitting data to the receiver of the other device. Figure 1 shows an RS-422 
       connection between two devices. 
@@ -66,7 +66,7 @@ pages:
       wires. 
        
        
-       Revision 1.0 AN6-1 
+        Revision 1.0  AN6-1  
   -
     content: |-
       Application Note AN-6 
@@ -74,7 +74,7 @@ pages:
        
        
        
-      RS-422 DeviceRS-422 Device
+      RS-422 Device RS-422 Device
        
        
       Figure 1. RS-422 Interface Example 
@@ -82,7 +82,7 @@ pages:
          
        
        
-      RS-485 DeviceRS-485 DeviceRS-485 Device
+      RS-485 Device RS-485 Device RS-485 Device
       Each device ouputs
       data in-turn to all other
       devices.
@@ -94,7 +94,7 @@ pages:
        
        
        
-      Control PanelControl PanelControl Panel
+      Control Panel Control Panel Control Panel
       Each Control Panel
       ouputs data in-turn to the
       System Controller input.
@@ -105,7 +105,7 @@ pages:
        
        
       Figure 3. MPK Interface Example 
-      AN6-2 Revision 1.0 
+      AN6-2  Revision 1.0 
   -
     content: |2-
        Application Note AN-6 
@@ -142,13 +142,13 @@ pages:
       7707DT fiber link. Figures 4 and 5 describe correct and incorrect interface methods, respectively. 
       Figure 6 describes pin-for-pin connections for the correct method.  
        
-       Revision 1.0 AN6-3 
+        Revision 1.0  AN6-3  
   -
     content: |-
       Application Note AN-6 
       MPK Router Control Interface to 7707DT 
        
-      Control PanelControl PanelControl Panel
+      Control Panel Control Panel Control Panel
       Set to
       RS-422
       7707DT
@@ -161,12 +161,12 @@ pages:
       Figure 4. MPK Interface to RS-422. Correct Method 
        
        
-      Control PanelControl PanelControl Panel
+      Control Panel Control Panel Control Panel
       Set to
       RS-422
       Control Panel output
       will contend with 7707DT
-      Incorrect Methodoutput. W ill not work.
+      Incorrect Method output. W ill not work.
       7707DT
       Set to
       RS-422
@@ -175,7 +175,7 @@ pages:
        
        
       Figure 5. MPK Interface to RS-422. Incorrect Method 
-      AN6-4 Revision 1.0 
+      AN6-4  Revision 1.0 
   -
     content: |2-
        Application Note AN-6 
@@ -183,72 +183,72 @@ pages:
        
        
       7707DT Channel 1 is configured
-      Control PanelControl Panelto RS-422 for this example.
-      7707DT7707DT
-      12345
-      GND- TX+RX------
-      6789
-      ---+TX-RX---
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      -RS485-RS485
+      Control Panel Control Panel to RS-422 for this example.
+      7707DT 7707DT
+      1 2 3 4 5
+      GND - TX +RX --- ---
+      6 7 8 9
+      --- +TX -RX ---
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      -RS485 -RS485
       CH1
       CH1
-      +RS422 OUT+RS422 OUT
+      +RS422 OUT +RS422 OUT
       RS-422
       RS-422
-      -RS422 IN-RS422 IN
-      RS232 INRS232 OUTRS232 INRS232 OUT
-      CH1CH1CH1CH1
-      GNDGNDGNDGND
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      -RS485-RS485
+      -RS422 IN -RS422 IN
+      RS232 IN RS232 OUT RS232 IN RS232 OUT
+      CH1 CH1 CH1 CH1
+      GND GND GND GND
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      -RS485 -RS485
       CH2
       CH2
-      +RS422 OUT+RS422 OUT
-      -RS422 IN-RS422 IN
+      +RS422 OUT +RS422 OUT
+      -RS422 IN -RS422 IN
       RS-422
       RS-422
-      RS232 INRS232 OUTRS232 INRS232 OUT
-      CH2CH2CH2CH2
-      GNDGNDGNDGND
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      -RS485-RS485
+      RS232 IN RS232 OUT RS232 IN RS232 OUT
+      CH2 CH2 CH2 CH2
+      GND GND GND GND
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      -RS485 -RS485
       CH3
       CH3
-      +RS422 OUT+RS422 OUT
+      +RS422 OUT +RS422 OUT
       RS-422
       RS-422
-      -RS422 IN-RS422 IN
-      RS232 INRS232 OUTRS232 INRS232 OUT
-      CH3CH3CH3CH3
-      GNDGNDGNDGND
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      12345
-      -RS485-RS485
+      -RS422 IN -RS422 IN
+      RS232 IN RS232 OUT RS232 IN RS232 OUT
+      CH3 CH3 CH3 CH3
+      GND GND GND GND
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      1 2 3 4 5
+      -RS485 -RS485
       CH4
       CH4
-      GND- RX+TX------
-      +RS422 OUT+RS422 OUT
+      GND - RX +TX --- ---
+      +RS422 OUT +RS422 OUT
       RS-422
       RS-422
-      -RS422 IN-RS422 IN
-      6789
-      ---+RX-TX---
-      +LTC IN+LTC OUT+LTC IN+LTC OUT
-      GNDGNDGNDGND
-      -LTC IN-LTC OUT-LTC IN-LTC OUT
+      -RS422 IN -RS422 IN
+      6 7 8 9
+      --- +RX -TX ---
+      +LTC IN +LTC OUT +LTC IN +LTC OUT
+      GND GND GND GND
+      -LTC IN -LTC OUT -LTC IN -LTC OUT
       Jupiter System Controller
        
       Figure 6. MPK Interface to RS-422 
-       Revision 1.0 AN6-5 
+        Revision 1.0  AN6-5  
   -
     content: |-
       Application Note AN-6 
@@ -274,7 +274,7 @@ pages:
       Figures 7 shows a block diagram describing this method of interface. Figure 8 describes pin-for-pin 
       connections. 
        
-      Control PanelControl PanelControl Panel
+      Control Panel Control Panel Control Panel
       Set to
       RS-422
       Set to
@@ -293,7 +293,7 @@ pages:
        
        
        
-      AN6-6 Revision 1.0 
+      AN6-6  Revision 1.0 
   -
     content: |2-
        Application Note AN-6 
@@ -302,74 +302,74 @@ pages:
        
       7707DT Channel 1 is configured
       to RS-422 for this example.
-      Control PanelControl Panel
+      Control Panel Control Panel
       7707DT Channel 2 is configured
       to RS-485 @1200baud for this example.
-      7707DT7707DT
-      12345
-      GND- TX+RX------
-      6789
-      ---+TX-RX---
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      -RS485-RS485
+      7707DT 7707DT
+      1 2 3 4 5
+      GND - TX +RX --- ---
+      6 7 8 9
+      --- +TX -RX ---
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      -RS485 -RS485
       CH1
       CH1
-      +RS422 OUT+RS422 OUT
+      +RS422 OUT +RS422 OUT
       RS-422
       RS-422
-      -RS422 IN-RS422 IN
-      RS232 INRS232 OUTRS232 INRS232 OUT
-      CH1CH1CH1CH1
-      GNDGNDGNDGND
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      -RS485-RS485
+      -RS422 IN -RS422 IN
+      RS232 IN RS232 OUT RS232 IN RS232 OUT
+      CH1 CH1 CH1 CH1
+      GND GND GND GND
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      -RS485 -RS485
       CH2
       CH2
-      +RS422 OUT+RS422 OUT
-      -RS422 IN-RS422 IN
+      +RS422 OUT +RS422 OUT
+      -RS422 IN -RS422 IN
       RS-422
       RS-422
-      RS232 INRS232 OUTRS232 INRS232 OUT
-      CH2CH2CH2CH2
-      GNDGNDGNDGND
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      -RS485-RS485
+      RS232 IN RS232 OUT RS232 IN RS232 OUT
+      CH2 CH2 CH2 CH2
+      GND GND GND GND
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      -RS485 -RS485
       CH3
       CH3
-      +RS422 OUT+RS422 OUT
+      +RS422 OUT +RS422 OUT
       RS-422
       RS-422
-      -RS422 IN-RS422 IN
-      RS232 INRS232 OUTRS232 INRS232 OUT
-      CH3CH3CH3CH3
-      GNDGNDGNDGND
-      +RS485+RS485
-      -RS422 OUT-RS422 OUT
-      +RS422 IN+RS422 IN
-      12345
-      -RS485-RS485
+      -RS422 IN -RS422 IN
+      RS232 IN RS232 OUT RS232 IN RS232 OUT
+      CH3 CH3 CH3 CH3
+      GND GND GND GND
+      +RS485 +RS485
+      -RS422 OUT -RS422 OUT
+      +RS422 IN +RS422 IN
+      1 2 3 4 5
+      -RS485 -RS485
       CH4
       CH4
-      GND- RX+TX------
-      +RS422 OUT+RS422 OUT
+      GND - RX +TX --- ---
+      +RS422 OUT +RS422 OUT
       RS-422
       RS-422
-      -RS422 IN-RS422 IN
-      6789
-      ---+RX-TX---
-      +LTC IN+LTC OUT+LTC IN+LTC OUT
-      GNDGNDGNDGND
-      -LTC IN-LTC OUT-LTC IN-LTC OUT
-      Jupiter System ControllerControl Panel
+      -RS422 IN -RS422 IN
+      6 7 8 9
+      --- +RX -TX ---
+      +LTC IN +LTC OUT +LTC IN +LTC OUT
+      GND GND GND GND
+      -LTC IN -LTC OUT -LTC IN -LTC OUT
+      Jupiter System Controller Control Panel
        
       Figure 8. MPK Interface to RS-485 
-       Revision 1.0 AN6-7 
+        Revision 1.0  AN6-7  
   -
     content: |-
       Application Note AN-6 
@@ -384,7 +384,7 @@ pages:
       Signal terminations are used to eliminate distortion of signals traveling over long lengths of cable. If 
       problems are experienced, and signal distortion is suspected, then the user should enable the input 
       termination of the respective 7707DT. Input terminations are easily selectable through the card edge 
-      interface of the 7707DT, or via VistalinkTM, as described in the product manual. As a general rule, 
+      interface of the 7707DT, or via Vista linkTM, as described in the product manual. As a general rule, 
       terminations are most effective when placed at the far end of a cable. If more than two devices are 
       connected to the same cable, as could be the case with MPK interfaces, then it is recommended that 
       the 7707DT be located at the far end of the longest cable segment when possible.  
@@ -393,10 +393,10 @@ pages:
       bias, as it places the balanced input connections in a known logic state while no device is transmitting 
       to them. Any direct connection between a 7707DT input and a Control Panel may require a failsafe 
       bias, to compensate for ambient noise, long lengths of cable, or connection to many devices. Input 
-      failsafe bias is easily selectable through the card edge interface of the 7707DT, or via VistalinkTM, as 
+      failsafe bias is easily selectable through the card edge interface of the 7707DT, or via  Vista linkTM, as 
       described in the product manual. To enable failsafe bias on any channel of the 7707DT, the termination 
       must first be enabled.  
-      AN6-8 Revision 1.0 
+      AN6-8  Revision 1.0 
   -
     content: |2-
        Application Note AN-6 
@@ -431,4 +431,4 @@ pages:
        
        
        
-       Revision 1.0 AN6-9 
+        Revision 1.0  AN6-9  

--- a/tests/Samples/files/word365-lorem-ipsum-with-titles-and-formatting/contents.yml
+++ b/tests/Samples/files/word365-lorem-ipsum-with-titles-and-formatting/contents.yml
@@ -13,7 +13,7 @@ pages:
   -
     content: |-
       Nam quod molestias vel corporis aperiam.  
-      Lorem ipsum dolor sit amet. Et omnis perferendis Et quisquam qui laboriosam 
+      Lorem ipsum dolor sit amet. Et omnis perferendis  Et quisquam qui laboriosam 
       explicabo et natus corrupti aut repudiandae iure quo inventore itaque et odio atque. 
       Qui necessitatibus odit et commodi accusamus Et fuga!  
       Qui distinctio praesentium sed corporis reiciendis eum molestiae eius.  
@@ -24,37 +24,37 @@ pages:
       harum.  
       Est incidunt repellat aut iusto odit.  
       Et magnam incidunt eum possimus perspiciatis Quo pariatur aut perferendis 
-      laboriosam eum repellat ipsa ut debitis ipsa ut distinctio dolores! Et rerum 
+      laboriosam eum repellat ipsa ut debitis ipsa  ut distinctio dolores! Et rerum 
       expeditaAut ullam ad ullam deleniti est facilis consequatur ut architecto nobis.  
       Non debitis expedita ea reprehenderit asperiores et voluptatem quos.  
       Non minima soluta Sed delectus qui repellendus dolorem et galisum quia. Non sunt 
       debitis ab vitae aspernatur Ex minus eum optio assumenda est voluptatem illum et 
       harum ipsam rem veniam culpa. Aut adipisci deserunt non inventore ratione Hic iste 
-      vel sint unde non soluta nulla in culpa iure et quia recusandae? Qui veniam quia id 
+      vel sint unde non soluta nulla in culpa iure  et quia recusandae? Qui veniam quia id 
       maiores excepturiQui dolores et officia aperiam ab sint excepturi.  
       Est molestias illum est dolorem praesentium cum soluta nesciunt.  
       Ut velit aspernatur ut earum debitis Qui ullam aut quod dolorum quo molestiae 
-      magni et corrupti minima. Id dolor error ab dignissimos corporis Quo commodi. Et 
+      magni et corrupti minima . Id dolor error ab dignissimos corporis Quo commodi. Et 
       soluta doloribus Eos quae in magnam praesentium aut accusantium laboriosam non 
       nemo reprehenderit.  
-      Et eveniet ducimus Ut voluptatem et porro velit id suscipit impedit! Vel culpa itaque Eos 
-      fuga aut totam laudantium qui eveniet molestiae vel dolores fugiat.  
+      Et eveniet ducimus Ut voluptatem et porro velit id suscipit impedit! Vel culpa itaque  Eos 
+      fuga aut totam laudantium qui eveniet molestiae vel dolores fugiat .  
       Est saepe soluta et vero voluptatemQuo maxime! Eos tempora quas ad nesciunt itaque 
-      Ea nihil et ullam repellat et voluptatem delectus. Aut voluptatum pariatur Id 
+      Ea nihil et ullam repellat et voluptatem delectus . Aut voluptatum pariatur Id 
       molestias cum nobis molestias. Ut velit distinctioEx consectetur eos debitis 
   -
     content: |-
       perspiciatis a minus commodi eos doloribus autem vel accusamus sequi et quidem 
       reiciendis.  
-      • Ut autem excepturi ut sequi laboriosam est quas debitis et placeat consequatur!  
-      • Qui autem voluptas eum deserunt dolor.  
-      • In nesciunt quia qui asperiores corrupti sed perspiciatis tempora id minus 
+      •  Ut autem excepturi ut sequi laboriosam est quas debitis et placeat consequatur!  
+      •  Qui autem voluptas eum deserunt dolor.  
+      •  In nesciunt quia qui asperiores corrupti sed perspiciatis tempora id minus 
       architecto!  
-      • Rem beatae quos aut fugit vero.  
-      • At adipisci enim id reiciendis officiis.  
-      • Sed sapiente quia qui sint dolorem vel impedit magni.  
+      •  Rem beatae quos aut fugit vero.  
+      •  At adipisci enim id reiciendis officiis.  
+      •  Sed sapiente quia qui sint dolorem vel impedit magni.  
       Et dicta voluptatem sit fugit saepevel nulla et debitis iure et ipsa voluptas? Est facere 
-      harum et inventore eveniet Aut rerum est molestias quam qui perspiciatis magnam.  
+      harum et inventore eveniet Aut rerum est molestias quam qui perspiciatis magnam .  
       Qui eligendi saepe et neque autem A omnis et pariatur rerum est dolore rerum est 
       facere quasi. Sit dolorem quiaet veritatis rem alias deleniti. Et voluptatem laborum et 
       impedit atqueaut suscipit. Rem unde quos cum reprehenderit temporeQui eaque sit 
@@ -63,9 +63,9 @@ pages:
       explicabo. Et maxime assumenda et ipsam itaqueAut deleniti ut excepturi alias et fugit 
       facere non modi laudantium. Qui sapiente rerum non sunt ipsum Ad maxime est velit 
       eligendi aut quaerat officia est architecto magnam?  
-      1. Et sequi ipsum et expedita ipsum eum dolore laborum.  
-      2. Id enim unde eos commodi quidem et eius quaerat.  
-      3. Est tempore veritatis sed aliquam Quis.  
-      4. Qui quas tempora ut voluptates doloribus est facilis deserunt 33 distinctio 
+      1.  Et sequi ipsum et expedita ipsum eum dolore laborum.  
+      2.  Id enim unde eos commodi quidem et eius quaerat.  
+      3.  Est tempore veritatis sed aliquam Quis.  
+      4.  Qui quas tempora ut voluptates doloribus est facilis deserunt 33 distinctio 
       internos. 
        


### PR DESCRIPTION
CID font widths are represented as `em` units throughout the code, eg. their width is divided by 1000 in `RangeCIDWidth.php` and `ConsecutiveCIDWidth.php`. This division by 1000 was not done for simple fonts in `FontWidths.php`. The result was that when calculating the advance width to decide if a space needs to be inserted between texts, the width for simple (eg. ASCII only) fonts were 1000 times too large. This resulted in some words not being separated correctly.

This PR fixes this by also dividing the simple font widths by 1000.

Obviously this changes how a lot of the samples are parsed. There are several obvious improvements:

```
  CH1CH1CH1CH1                          -> CH1 CH1 CH1 CH1
  RS232 INRS232 OUTRS232 INRS232 OUT    -> RS232 IN RS232 OUT RS232 IN RS232 OUT
  Control PanelControl PanelControl Panel -> Control Panel Control Panel Control Panel
  20232024Veraenderung                  -> 2023 2024 Veraenderung
  ...973.606169.622187.39325.376...      -> ...973.606 169.622 187.393 25.376...
  sit ametviverra                       -> sit amet viverra
  *Ut autem excepturi...                -> * Ut autem excepturi...
```

Unfortunately it also overinserts spaces sometimes. Most of them are harmless for the case of text extraction (two spaces instead of one, spaces around some punctuation marks) but in somewhat rare cases it also splits valid words ("Worte" -> "W orte").

I still think this implementation is more correct and fixes more cases than it overcorrects.

Note: this is also a pre-requisite for an up-coming PR I am working on that will correctly handle rotated text - without correctly calculated glyph widths it get's real weird otherwise.