### PR TITLE
Parse padded CIDFont /W arrays without shifting glyph widths

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Array/CIDFontWidths.php
+++ b/src/Document/Dictionary/DictionaryValue/Array/CIDFontWidths.php
@@ -6,6 +6,7 @@ use Override;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Array\Item\ConsecutiveCIDWidth;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\Array\Item\RangeCIDWidth;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\DictionaryValue;
+use PrinsFrank\PdfParser\Exception\RuntimeException;
 
 /** @see 9.7.4.3 Glyph metrics in CIDFonts */
 class CIDFontWidths implements DictionaryValue {
@@ -47,7 +48,12 @@ class CIDFontWidths implements DictionaryValue {
             }
 
             if (str_starts_with($match['CIDS'], '[') && str_ends_with($match['CIDS'], ']')) {
-                $widths[] = new ConsecutiveCIDWidth($startingCID, array_map('floatval', explode(' ', rtrim(ltrim($match['CIDS'], '['), ']'))));
+                $cidWidths = preg_split('/\s+/', trim(rtrim(ltrim($match['CIDS'], '['), ']')), -1, PREG_SPLIT_NO_EMPTY);
+                if ($cidWidths === false) {
+                    throw new RuntimeException('Something went wrong while splitting');
+                }
+
+                $widths[] = new ConsecutiveCIDWidth($startingCID, array_map('floatval', $cidWidths));
 
                 continue;
             }

--- a/tests/Samples/files/gdocs-hello-world-simple-password/contents.yml
+++ b/tests/Samples/files/gdocs-hello-world-simple-password/contents.yml
@@ -11,4 +11,4 @@ creationDate: null
 modificationDate: null
 pages:
   -
-    content: 'H ello w o r ld'
+    content: 'Hello world'

--- a/tests/Samples/files/issue-215/contents.yml
+++ b/tests/Samples/files/issue-215/contents.yml
@@ -12,7 +12,7 @@ modificationDate: 2025-09-01T16:24:09+02:00
 pages:
   -
     content: |-
-      Deutscher Bundestag Drucksache 21/ 1407
+      Deutscher Bundestag Drucksache 21/1407
       21. Wahlperiode 28.08.2025
       Antwort 
       der Bundesregierung 
@@ -34,7 +34,7 @@ pages:
       den. Der Aufstellungsbeschluss zum Bebauungsplan „Bundeskriminalamt“ in 
       den Ortsbezirken Erbenheim und Südost der Landeshauptstadt Wiesbaden 
       wurde am 2. April 2025 von der Stadtverordnetenversammlung beschlossen 
-      (https://piwi.wiesbaden.de/sitzungsvorlage/detail/3434709 ).
+      (https://piwi.wiesbaden.de/sitzungsvorlage/detail/3434709).
       Das Vorhaben ist Teil eines größeren Plans zur Schaffung eines neuen Stadt-
       teils, stößt jedoch auf erheblichen Widerstand. Konfliktlinien verlaufen ent-
       lang verschiedener Interessen: Landwirte wehren sich gegen den Verlust wert-
@@ -42,9 +42,9 @@ pages:
       wirtschaft und regionale Grünzüge ausgewiesen sind. Die am Rhein liegenden 
       Stadtteile Kastel und Kostheim sowie der anliegende Stadtteil Erbenheim ge-
       hören nach der landesweiten Klimaanalyse Hessen zu den durch Hitzestress 
-      besonders belasteten Gebieten ( https://landesplanung.hessen.de/sites/landespla
+      besonders belasteten Gebieten (https://landesplanung.hessen.de/sites/landespla
       nung.hessen.de/files/2024-10/landeswklimaanalysehessen_abschlussbericht_2
-      0240918.pdf , S. 67 f.).
+      0240918.pdf, S. 67 f.).
       Zudem hat der Bund für Umwelt und Naturschutz (BUND) Hessen gegen die 
       mit dem Vorhaben verbundene Abweichung vom Regionalplan geklagt. Zwar 
       wurde die Klage zunächst abgewiesen, das Urteil ist aber noch nicht rechts-
@@ -58,7 +58,7 @@ pages:
       Die Drucksache enthält zusätzlich – in kleinerer Schrifttype – den Fragetext.
   -
     content: |-
-      Drucksache 21/ 1407 – 2 – Deutscher Bundestag – 21. Wahlperiode
+      Drucksache 21/1407 – 2 – Deutscher Bundestag – 21. Wahlperiode
       BKA und BImA, sowie zur Gesamtverantwortlichkeit und Koordination des 
       geplanten BKA-Neubaus in Wiesbaden befragt.
       Vorbemerkung der Bundesregierung
@@ -105,7 +105,7 @@ pages:
       gen.
   -
     content: |-
-      Deutscher Bundestag – 21. Wahlperiode – 3 – Drucksache 21/ 1407
+      Deutscher Bundestag – 21. Wahlperiode – 3 – Drucksache 21/1407
        3. Spielt die Nähe des US-Headquarters Europe und des NATO-Haupt-
       quartiers zur Koordinierung von Waffenlieferungen und Ausbildungsak-
       tivitäten für die Ukraine eine Rolle, und wenn ja, welche?
@@ -143,7 +143,7 @@ pages:
       den Gesamtkosten getätigt werden (siehe Vorbemerkung).
   -
     content: |-
-      Drucksache 21/ 1407 – 4 – Deutscher Bundestag – 21. Wahlperiode
+      Drucksache 21/1407 – 4 – Deutscher Bundestag – 21. Wahlperiode
        9. Wie stellt sich die sicherlich vorgenommene umfassende Wirtschaftlich-
       keitsanalyse dar, die den Neubau mit einer Sanierung und Modernisie-
       rung der bestehenden BKA-Standorte vergleicht, unter Berücksichtigung 
@@ -189,7 +189,7 @@ pages:
       wickelt (bitte eine jährliche Durchschnittsquote seit 2019 nennen)?
   -
     content: |-
-      Deutscher Bundestag – 21. Wahlperiode – 5 – Drucksache 21/ 1407
+      Deutscher Bundestag – 21. Wahlperiode – 5 – Drucksache 21/1407
       15. Mit welcher Quote der mobilen Arbeit (Homeoffice) rechnet das BKA in 
       Zukunft?
       Die Fragen 13 bis 15 werden gemeinsam beantwortet.
@@ -230,7 +230,7 @@ pages:
       Enteignung statt?
   -
     content: |-
-      Drucksache 21/ 1407 – 6 – Deutscher Bundestag – 21. Wahlperiode
+      Drucksache 21/1407 – 6 – Deutscher Bundestag – 21. Wahlperiode
       24. Welche Erkenntnisse liegen der Bundesregierung über die ökologischen 
       Auswirkungen des BKA-Neubaus im Ostfeld/Kalkofen vor, insbesondere 
       in Bezug auf den Verlust von 26 Hektar hochwertiger Ackerböden?
@@ -253,7 +253,7 @@ pages:
       30. Welche Auswirkungen könnte die geplante Bodenversiegelung auf das 
       lokale Klima und die Luftqualität haben?
       31. Welche Maßnahmen hält die Bundesregierung für notwendig, um negati-
-      ve klimatische Effekte, wie eine Verschlechterung der CO2 -Bilanz oder 
+      ve klimatische Effekte, wie eine Verschlechterung der CO2-Bilanz oder 
       die Entstehung von städtischen Hitzeinseln, durch das Bauprojekt zu ver-
       hindern oder zu minimieren?
       32. Welche Maßnahmen sind vorgesehen, um insbesondere die Folgen von 
@@ -278,7 +278,7 @@ pages:
       für veranschlagten Gesamtkosten?
   -
     content: |-
-      Deutscher Bundestag – 21. Wahlperiode – 7 – Drucksache 21/ 1407
+      Deutscher Bundestag – 21. Wahlperiode – 7 – Drucksache 21/1407
       b) Wie wird sichergestellt, dass diese Maßnahmen die Existenz der 
       landwirtschaftlichen Betriebe tatsächlich sichern und nicht nur kurz-
       fristige Kompensationen darstellen?
@@ -323,7 +323,7 @@ pages:
       mäßig gemonitored und ist integraler Teil der Projektsteuerung.
   -
     content: |-
-      Drucksache 21/ 1407 – 8 – Deutscher Bundestag – 21. Wahlperiode
+      Drucksache 21/1407 – 8 – Deutscher Bundestag – 21. Wahlperiode
       c) Welche Behörde leitet das BKA-Neubauprojekt federführend und trägt 
       damit die Gesamtverantwortung?
       Bauherrin für das Bauprojekt ist die BImA.

--- a/tests/Samples/files/issue-290/contents.yml
+++ b/tests/Samples/files/issue-290/contents.yml
@@ -12,7 +12,7 @@ modificationDate: 2025-09-12T14:25:52+02:00
 pages:
   -
     content: |-
-      Deutscher Bundestag Drucksache 21/ 1576
+      Deutscher Bundestag Drucksache 21/1576
       21. Wahlperiode 10.09.2025
       Antwort 
       der Bundesregierung 
@@ -26,7 +26,7 @@ pages:
       zitiert:
       „Der Zentralrat ist auch das Dach der jüdischen Gemeinden und vertritt alle 
       Denominationen. Er ist die gesellschaftliche, politische und religiöse Vertre-
-      tung des deutschen Judentums.“ ( www.faz.net/aktuell/politik/inland/schuster-
+      tung des deutschen Judentums.“ (www.faz.net/aktuell/politik/inland/schuster-
       bezeichnet-wadephuls-aeusserung-ueber-zwangssolidaritaet-als-entgleisung-1
       10593344.html). Ergänzt wird diese Aussage von Josef Schuster noch mit dem 
       Hinweis auf die vom Zentralrat initiierte Gründung der Nathan Peter Levinson 
@@ -56,7 +56,7 @@ pages:
       Die Drucksache enthält zusätzlich – in kleinerer Schrifttype – den Fragetext.
   -
     content: |-
-      Drucksache 21/ 1576 – 2 – Deutscher Bundestag – 21. Wahlperiode
+      Drucksache 21/1576 – 2 – Deutscher Bundestag – 21. Wahlperiode
       haben, vgl. auch die Gesetzesbegründung zu den Artikeln 4 und 5 des Vertra-
       ges, Bundestagsdrucksache 15/879, S. 13.
       Nach Artikel 6 Absatz 1 des Vertrages wird der Zentralrat der Juden über die in 
@@ -87,9 +87,9 @@ pages:
       than Peter Levinson Stiftung.
       3. Wurde der Zentralrat der Juden in Deutschland als Religionsgemeinschaft 
       anerkannt, und wenn ja, wann, und woraus leitet sich der Anspruch ab, 
-      „die religiöse Vertretung des Deutschen Judentums“ zu sein ( www.faz.net/
+      „die religiöse Vertretung des Deutschen Judentums“ zu sein (www.faz.net/
       aktuell/politik/inland/schuster-bezeichnet-wadephuls-aeusserung-ueber-zw
-      angssolidaritaet-als-entgleisung-110593344.html )?
+      angssolidaritaet-als-entgleisung-110593344.html)?
       Es gibt in der Bundesrepublik Deutschland kein förmliches Verfahren für die 
       Anerkennung als Religionsgemeinschaft. Das Grundrecht der Religions- und 
       Weltanschauungsfreiheit aus Artikel 4 Absatz 1 und 2 des Grundgesetzes um-
@@ -102,7 +102,7 @@ pages:
       dürfen.
   -
     content: |-
-      Deutscher Bundestag – 21. Wahlperiode – 3 – Drucksache 21/ 1576
+      Deutscher Bundestag – 21. Wahlperiode – 3 – Drucksache 21/1576
       4. a) Ist nach Ansicht der Bundesregierung der Zentralrat der Juden in 
       Deutschland der religiöse Vertreter des Liberalen Judentums, und 
       wenn ja, wie begründet die Bundesregierung die Nichtbeachtung der 
@@ -157,7 +157,7 @@ pages:
       Aufgaben des Zentralrats“ sowie von „überregionalen Aufgaben“, vgl. Arti-
   -
     content: |-
-      Drucksache 21/ 1576 – 4 – Deutscher Bundestag – 21. Wahlperiode
+      Drucksache 21/1576 – 4 – Deutscher Bundestag – 21. Wahlperiode
       kel 1 Satz 2 und 3 des Vertrages. Im Übrigen wird auf die Antwort zu Frage 1 
       verwiesen.
       6. Wie berücksichtigte die Bundesregierung bei der Erstellung des Haus-
@@ -166,7 +166,7 @@ pages:
       K.d.ö.R. UPJ gehört und nicht bereit war, von der Verteilung staatlicher 
       Mittel ausgeschlossen zu sein (Bundesverwaltungsgericht (BVerwG), Ur-
       teil vom 28. Februar 2002 – 7 C 7.01; Oberverwaltungsgericht (OVG) 
-      Sachsen-Anhalt http://lexetius.com/2002,2130 )?
+      Sachsen-Anhalt http://lexetius.com/2002,2130)?
       7. Wie setzt die Bundesregierung die verfassungsrechtlichen Vorgaben aus 
       den ergangenen Leitsätzen, z. B. der Staat dürfe eine Religionsgemein-
       schaft nicht in ein Abhängigkeitsverhältnis von einer anderen Religionsge-

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Array/CIDFontWidthsTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Array/CIDFontWidthsTest.php
@@ -48,6 +48,18 @@ class CIDFontWidthsTest extends TestCase {
         );
     }
 
+    public function testFromValueWithPaddedBrackets(): void {
+        static::assertEquals(
+            new CIDFontWidths(
+                new ConsecutiveCIDWidth(43, [722.16797]),
+                new RangeCIDWidth(71, 72, 556.15234),
+                new ConsecutiveCIDWidth(79, [222.16797, 0, 0, 556.15234, 0, 0, 333.00781]),
+                new ConsecutiveCIDWidth(90, [722.16797]),
+            ),
+            CIDFontWidths::fromValue('[ 43 [ 722.16797 ] 71 72 556.15234 79 [ 222.16797 0 0 556.15234 0 0 333.00781 ] 90 [ 722.16797 ] ]'),
+        );
+    }
+
     public function testFromValueAcceptsEmptyArray(): void {
         static::assertEquals(
             new CIDFontWidths(),


### PR DESCRIPTION
I stumbled across this issue while working on something else. This fixes a simple issue with padded `/W` arrays. It fixes a few obvious whitespace bugs.
