### PR TITLE
Normalize white-space and odd digit counts in hexadecimal strings

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/TextString/TextStringValue.php
+++ b/src/Document/Dictionary/DictionaryValue/TextString/TextStringValue.php
@@ -41,6 +41,7 @@ readonly class TextStringValue implements DictionaryValue {
         return PDFDocEncoding::textToUnicode($binaryValue);
     }
 
+    /** @throws ParseFailureException */
     public function getBinaryString(): string {
         if (str_starts_with($this->textStringValue, '(') && str_ends_with($this->textStringValue, ')')) {
             $value = preg_replace_callback(
@@ -57,7 +58,16 @@ readonly class TextStringValue implements DictionaryValue {
         }
 
         if (str_starts_with($this->textStringValue, '<') && str_ends_with($this->textStringValue, '>')) {
-            $string = substr($this->textStringValue, 1, -1);
+            $string = preg_replace('/[\x00\x09\x0A\x0C\x0D\x20]+/', '', substr($this->textStringValue, 1, -1))
+                ?? throw new ParseFailureException();
+            if (preg_match('/^[0-9A-Fa-f]*$/', $string) !== 1) {
+                throw new ParseFailureException(sprintf('Invalid hex string %s', $this->textStringValue));
+            }
+
+            if (strlen($string) % 2 !== 0) {
+                $string .= '0';
+            }
+
             $binaryValue = hex2bin($string);
             if ($binaryValue === false) {
                 throw new ParseFailureException('Invalid hex string');

--- a/tests/Unit/Document/Dictionary/DictionaryValue/TextString/TextStringValueTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/TextString/TextStringValueTest.php
@@ -5,6 +5,7 @@ namespace PrinsFrank\PdfParser\Tests\Unit\Document\Dictionary\DictionaryValue\Te
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use PrinsFrank\PdfParser\Document\Dictionary\DictionaryValue\TextString\TextStringValue;
+use PrinsFrank\PdfParser\Exception\ParseFailureException;
 
 #[CoversClass(TextStringValue::class)]
 class TextStringValueTest extends TestCase {
@@ -128,6 +129,33 @@ class TextStringValueTest extends TestCase {
             '•€',
             (new TextStringValue('<80A0>'))->getText(),
         );
+    }
+
+    /** @see 7.3.4.3 — a final missing digit in a hexadecimal string is assumed to be 0 */
+    public function testGetBinaryStringPadsOddLengthHexString(): void {
+        static::assertSame(
+            "\x90\x1F\xA0",
+            (new TextStringValue('<901FA>'))->getBinaryString(),
+        );
+    }
+
+    /** @see 7.3.4.3 — white-space within a hexadecimal string is ignored */
+    public function testGetBinaryStringIgnoresWhitespaceInHexString(): void {
+        static::assertSame(
+            "\x90\x1F\xA3",
+            (new TextStringValue("<90 1F\tA3>"))->getBinaryString(),
+        );
+
+        static::assertSame(
+            'He',
+            (new TextStringValue("<FE FF 00 48\n00 65>"))->getText(),
+        );
+    }
+
+    /** @see 7.3.4.3 — a hexadecimal string with non-hex content is rejected */
+    public function testGetBinaryStringRejectsInvalidHexString(): void {
+        $this->expectException(ParseFailureException::class);
+        (new TextStringValue('<90ZZ>'))->getBinaryString();
     }
 
     /** @see 7.3.5, table 4 */


### PR DESCRIPTION
Per 7.3.4.3, white-space within a hexadecimal string is ignored and a missing final digit is assumed to be 0. Such spec-valid strings were passed straight to hex2bin(), which emitted a warning and returned false, so the string was rejected and its text lost.