### PR TITLE
Apply the font /Differences array to every byte of a text segment

### DIFF
--- a/src/Document/ContentStream/PositionedText/TextSegment/TextSegment.php
+++ b/src/Document/ContentStream/PositionedText/TextSegment/TextSegment.php
@@ -16,20 +16,35 @@ readonly class TextSegment {
 
     public function getText(?DifferencesArrayValue $differences, ?EncodingNameValue $encoding, ?ToUnicodeCMap $toUnicodeCMap): string {
         $binaryString = $this->textString->getBinaryString();
-        if (strlen($binaryString) === 1 && ($glyph = $differences?->getGlyph(ord($binaryString))) !== null) {
-            $text = $glyph;
-        } elseif (in_array($encoding, [EncodingNameValue::MacExpertEncoding, EncodingNameValue::WinAnsiEncoding], true)
-            && $differences === null) {
-            $text = $encoding->decodeString($binaryString);
-        } elseif ($toUnicodeCMap !== null) {
-            $text = $toUnicodeCMap->textToUnicode(bin2hex($binaryString));
-        } elseif ($encoding !== null) {
-            $text = $encoding->decodeString($binaryString);
-        } else {
-            $text = $binaryString;
+        if ($differences === null) {
+            return $this->decode($binaryString, $encoding, $toUnicodeCMap);
+        }
+
+        $text = '';
+        for ($index = 0, $length = strlen($binaryString); $index < $length; $index++) {
+            $glyph = $differences->getGlyph(ord($binaryString[$index]));
+            $text .= $glyph !== null
+                ? $glyph
+                : $this->decode($binaryString[$index], $encoding, $toUnicodeCMap);
         }
 
         return $text;
+    }
+
+    private function decode(string $binaryString, ?EncodingNameValue $encoding, ?ToUnicodeCMap $toUnicodeCMap): string {
+        if (in_array($encoding, [EncodingNameValue::MacExpertEncoding, EncodingNameValue::WinAnsiEncoding], true)) {
+            return $encoding->decodeString($binaryString);
+        }
+
+        if ($toUnicodeCMap !== null) {
+            return $toUnicodeCMap->textToUnicode(bin2hex($binaryString));
+        }
+
+        if ($encoding !== null) {
+            return $encoding->decodeString($binaryString);
+        }
+
+        return $binaryString;
     }
 
     /** @return list<int> */

--- a/tests/Samples/files/type1-differences-non-ascii/contents.yml
+++ b/tests/Samples/files/type1-differences-non-ascii/contents.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=../../schema.json
+version: '1.4'
+userPassword: null
+ownerPassword: null
+fileEncryptionKey: null
+title: null
+producer: null
+author: null
+creator: null
+creationDate: null
+modificationDate: null
+pages:
+  -
+    content: 'Für Größe Übung'

--- a/tests/Samples/files/type1-differences-non-ascii/file.pdf
+++ b/tests/Samples/files/type1-differences-non-ascii/file.pdf
@@ -1,0 +1,37 @@
+%PDF-1.4
+%âãÏÓ
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 120] /Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 45 >>
+stream
+BT /F1 24 Tf 20 60 Td (Für Größe Übung) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /FirstChar 32 /LastChar 255 /Encoding 6 0 R >>
+endobj
+6 0 obj
+<< /Type /Encoding /Differences [ 196/Adieresis 214/Odieresis 220/Udieresis 223/germandbls 228/adieresis 246/odieresis 252/udieresis ] >>
+endobj
+xref
+0 7
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000342 00000 n 
+0000000456 00000 n 
+trailer
+<< /Size 7 /Root 1 0 R >>
+startxref
+609
+%%EOF


### PR DESCRIPTION
The /Differences array was only consulted for single byte text segments, so multi-byte strings shown with a font whose encoding is a /Differences array without a base encoding or /ToUnicode CMap fell through to their raw bytes. Non-ASCII glyphs such as umlauts were then emitted as raw single byte codes, producing invalid UTF-8.

Simple fonts are single byte encoded, so the array is now applied per byte for the whole segment, falling back to the base encoding for codes it does not remap, matching the encoding resolution in spec section 9.6.6.1.

I encountered this issue when trying to convert my 20+ year old Latex-generated diploma thesis - the issue seems to be rare for modern PDFs. The commit adds a synthetic test PDF - if you need my thesis for tests, let me know ;-)