### PR TITLE
Allow partial reference value arrays to be parsed as arrays in dictionary

### DIFF
--- a/src/Document/Dictionary/DictionaryValue/Array/ArrayValue.php
+++ b/src/Document/Dictionary/DictionaryValue/Array/ArrayValue.php
@@ -32,8 +32,11 @@ readonly class ArrayValue implements DictionaryValue {
         $sanitizedValueString = preg_replace('/\s+/', ' ', $sanitizedValueString)
             ?? throw new RuntimeException('An error occurred while removing duplicate spaces from array value');
         $values = explode(' ', $sanitizedValueString);
-        if (count($values) % 3 === 0 && array_key_exists(2, $values) && $values[2] === 'R') {
-            return ReferenceValueArray::fromValue($valueString);
+        if (count($values) % 3 === 0
+            && array_key_exists(2, $values)
+            && $values[2] === 'R'
+            && ($referenceValueArray = ReferenceValueArray::fromValue($valueString)) !== null) {
+            return $referenceValueArray;
         }
 
         $array = [];

--- a/tests/Unit/Document/Dictionary/DictionaryValue/Array/ArrayValueTest.php
+++ b/tests/Unit/Document/Dictionary/DictionaryValue/Array/ArrayValueTest.php
@@ -54,6 +54,14 @@ class ArrayValueTest extends TestCase {
             new ReferenceValueArray(new ReferenceValue(42, 0), new ReferenceValue(43, 0)),
             ArrayValue::fromValue('[42 0 R 43 0 R]'),
         );
+        static::assertEquals(
+            new ArrayValue(['459', '0', 'R', '/FitH', '10000']),
+            ArrayValue::fromValue(
+                <<<EOD
+                [ 459 0 R /FitH 10000]
+                EOD,
+            ),
+        );
     }
 
     public function testToString(): void {


### PR DESCRIPTION
fixes #459